### PR TITLE
feature: refactor write network chains function

### DIFF
--- a/_packages/initia-registry/scripts/build.js
+++ b/_packages/initia-registry/scripts/build.js
@@ -110,39 +110,31 @@ export default assets;
 };
 
 const writeNetworkChains = (filePath, networkObj) => {
-  const validChain = [];
+  const validChains = Object.keys(networkObj)
+    .filter(chainName => networkObj[chainName].chain)
+    .map(chainName => {
+      return `import * as _${chainName} from './${chainName}';`;
+    });
 
-  const importStat = Object.keys(networkObj)
-    .map((chain_name) => {
-      if (!networkObj[chain_name].chain) {
-        return null;
-      }
-
-      validChain.push(chain_name);
-      return `import * as _${chain_name} from './${chain_name}'`;
-    })
-    .filter(Boolean)
-    .join(";\n");
-
-  if (!validChain.length) {
+  if (validChains.length === 0) {
     return false;
   }
 
-  fs.writeFileSync(
-    filePath,
-    `import { Chain } from '@initia/initia-registry-types';
+  const importStatements = validChains.join('\n');
 
-${importStat}
+  const chains = validChains.map(chainName => `_${chainName}.chain`);
 
-const chains: Chain[] = [${validChain
-      .map((chain_name) => {
-        return `_${chain_name}.chain`;
-      })
-      .join(",")}];
+  const fileContent = `
+import { Chain } from '@initia/initia-registry-types';
+
+${importStatements}
+
+const chains: Chain[] = [${chains.join(', ')}];
 
 export default chains;
-`
-  );
+`;
+
+  fs.writeFileSync(filePath, fileContent);
 
   return true;
 };


### PR DESCRIPTION
Changes made:

1. Renamed validChain to validChains for clarity.
2. Changed map to filter and map combination to directly filter out invalid chains and generate import statements.
3. Refactored the way import statements are generated and joined.
4. Simplified the mapping of valid chains to chain objects.
5. Improved readability and spacing.