### PR TITLE
 Initia Testnet configuration and metadata

### DIFF
--- a/minitia/assetlist.json
+++ b/minitia/assetlist.json
@@ -1,0 +1,55 @@
+{
+  "testnet": {
+    "assets": [
+      {
+        "name": "INIT Token",
+        "symbol": "INIT",
+        "address": "0x1234567890abcdef1234567890abcdef12345678",
+        "decimals": 18,
+        "totalSupply": "1000000000"
+      },
+      {
+        "name": "Fake Ether",
+        "symbol": "fETH",
+        "address": "0xabcdef1234567890abcdef1234567890abcdef12",
+        "decimals": 18,
+        "totalSupply": "300000000"
+      },
+      {
+        "name": "Fake USDC",
+        "symbol": "fUSDC",
+        "address": "0x456789abcdef123456789abcdef123456789abcdef",
+        "decimals": 6,
+        "totalSupply": "100000000000"
+      },
+      {
+        "name": "Fake USDT",
+        "symbol": "fUSDT",
+        "address": "0x789abcdef123456789abcdef123456789abcdef123",
+        "decimals": 6,
+        "totalSupply": "100000000000"
+      },
+      {
+        "name": "Fake TUCANA",
+        "symbol": "fTUCANA",
+        "address": "0x987654abcdef987654abcdef987654abcdef987654",
+        "decimals": 18,
+        "totalSupply": "10000000"
+      },
+      {
+        "name": "Fake INITAI",
+        "symbol": "fINITAI",
+        "address": "0x654321abcdef654321abcdef654321abcdef654321",
+        "decimals": 18,
+        "totalSupply": "1000000000"
+      }
+    ]
+  },
+  "contributors": [
+    {
+      "name": "generisx.init",
+      "github": "Generis2001",
+      "walletAddress": "init12dz40g8tjtngtyr6atlrtaqknt5jdfu8xavqpt"
+    }
+  ]
+}

--- a/minitia/chain.json
+++ b/minitia/chain.json
@@ -1,0 +1,68 @@
+{
+  "chainId": "initia-chain-testnet",
+  "network": "testnet",
+  "consensus": {
+    "type": "PoS",  // Proof of Stake
+    "validators": [
+      {
+        "address": "0x1234567890abcdef1234567890abcdef12345678",
+        "stake": 1000000,
+        "commission": 0.02
+      },
+      {
+        "address": "0xabcdef1234567890abcdef1234567890abcdef12",
+        "stake": 500000,
+        "commission": 0.03
+      }
+    ]
+  },
+  "genesis": {
+    "timestamp": "2024-01-01T00:00:00Z",
+    "initialBalances": [
+      {
+        "address": "0x1111111111111111111111111111111111111111",
+        "balance": 10000000
+      },
+      {
+        "address": "0x2222222222222222222222222222222222222222",
+        "balance": 5000000
+      }
+    ],
+    "initialContracts": [
+      {
+        "address": "0x3333333333333333333333333333333333333333",
+        "code": "0x600160005260206000f3"
+      }
+    ]
+  },
+  "nodes": [
+    {
+      "url": "http://node1.initia.io:30303",
+      "publicKey": "0x123abc..."
+    },
+    {
+      "url": "http://node2.initia.io:30303",
+      "publicKey": "0x456def..."
+    }
+  ],
+  "parameters": {
+    "blockTime": "10s",
+    "gasLimit": 8000000,
+    "chainName": "Initia Testnet",
+    "symbol": "INIT"
+  },
+  "upgrades": {
+    "hardForks": [
+      {
+        "name": "Fork1",
+        "block": 100000,
+        "description": "Initial protocol upgrade to enhance transaction processing."
+      }
+    ]
+  },
+  "incentives": {
+    "contributors": [
+      {
+        "name": "generisx.init",
+        "github": "Generis2001",
+        "walletAddress": "init12dz40g8tjtngtyr6atlrtaqknt5jdfu8xavqpt"

--- a/minitia/initia-minitia.json
+++ b/minitia/initia-minitia.json
@@ -1,52 +1,46 @@
 {
-  "project": "Initia-Minitia",
-  "description": "A lightweight version of the Initia blockchain for testing and experimentation purposes.",
-  "version": "0.1.0",
-  "chainId": "initia-minitia",
+  "chainId": "initia",
   "network": "testnet",
-  "consensus": {
-    "type": "Proof of Authority (PoA)",
-    "validators": [
+  "ibc": {
+    "connections": [
       {
-        "address": "0x1234567890abcdef1234567890abcdef12345678",
-        "name": "Validator 1"
+        "id": "connection-1",
+        "clientID": "client-1",
+        "counterpartyChainID": "celestia-chain-id",
+        "counterpartyClientID": "CelestiaClientID",
+        "version": "1.0",
+        "state": "active"
       },
       {
-        "address": "0xabcdef1234567890abcdef1234567890abcdef12",
-        "name": "Validator 2"
-      }
-    ]
-  },
-  "genesis": {
-    "timestamp": "2024-06-01T00:00:00Z",
-    "initiaBalances": [
-      {
-        "address": "0x1111111111111111111111111111111111111111",
-        "balance": 10000000
-      },
-      {
-        "address": "0x2222222222222222222222222222222222222222",
-        "balance": 5000000
+        "id": "connection-2",
+        "clientID": "client-2",
+        "counterpartyChainID": "another-celestia-chain-id",
+        "counterpartyClientID": "CelestiaTestnetChainID",
+        "version": "1.0",
+        "state": "active"
       }
     ],
-    "initiaContracts": [
+    "channels": [
       {
-        "address": "0x3333333333333333333333333333333333333333",
-        "code": "0x600160005260206000f3"
+        "id": "channel-1",
+        "connectionID": "connection-1",
+        "order": "ordered",
+        "version": "1.0",
+        "state": "active"
+      },
+      {
+        "id": "channel-2",
+        "connectionID": "connection-2",
+        "order": "unordered",
+        "version": "1.0",
+        "state": "active"
       }
     ]
-  },
-  "parameters": {
-    "blockTime": "5s",
-    "gasLimit": 5000000,
-    "chainName": "Initia Testnet",
-    "symbol": "INIT"
   },
   "contributors": [
     {
       "name": "generisx.init",
-      "github": "Generis2001",
-      "walletAddress": "init12dz40g8tjtngtyr6atlrtaqknt5jdfu8xavqpt"
+      "github": "Generis2001"
     }
   ]
 }

--- a/minitia/initia-minitia.json
+++ b/minitia/initia-minitia.json
@@ -1,0 +1,52 @@
+{
+  "project": "Initia-Minitia",
+  "description": "A lightweight version of the Initia blockchain for testing and experimentation purposes.",
+  "version": "0.1.0",
+  "chainId": "initia-minitia",
+  "network": "testnet",
+  "consensus": {
+    "type": "Proof of Authority (PoA)",
+    "validators": [
+      {
+        "address": "0x1234567890abcdef1234567890abcdef12345678",
+        "name": "Validator 1"
+      },
+      {
+        "address": "0xabcdef1234567890abcdef1234567890abcdef12",
+        "name": "Validator 2"
+      }
+    ]
+  },
+  "genesis": {
+    "timestamp": "2024-06-01T00:00:00Z",
+    "initiaBalances": [
+      {
+        "address": "0x1111111111111111111111111111111111111111",
+        "balance": 10000000
+      },
+      {
+        "address": "0x2222222222222222222222222222222222222222",
+        "balance": 5000000
+      }
+    ],
+    "initiaContracts": [
+      {
+        "address": "0x3333333333333333333333333333333333333333",
+        "code": "0x600160005260206000f3"
+      }
+    ]
+  },
+  "parameters": {
+    "blockTime": "5s",
+    "gasLimit": 5000000,
+    "chainName": "Initia Testnet",
+    "symbol": "INIT"
+  },
+  "contributors": [
+    {
+      "name": "generisx.init",
+      "github": "Generis2001",
+      "walletAddress": "init12dz40g8tjtngtyr6atlrtaqknt5jdfu8xavqpt"
+    }
+  ]
+}


### PR DESCRIPTION
Below is description with valuable additions/changes.

1. Created chain.json with the configuration details for the Initia blockchain testnet, including consensus mechanism and parameters.
2. Added assetlist.json with a list of assets supported on the Initia testnet, including fake tokens for testing purposes.
3. Updated assetlist.json to adjust the total supply of various assets and change "Testnet Ether" to "Fake Ether" as requested.
4. Created initia-minitia.json with metadata for the Initia Minitia project, a lightweight version of the Initia blockchain for testing.
5. Added metadata entry to initia.json for IBC connections and channels, including counterparty chain and client IDs.
6. Included contributor information with name "generisx.init" and GitHub username "Generis2001" in the metadata files.

These given changes provide the foundational setup and necessary metadata for the Initia blockchain testnet, facilitating testing and experimentation. Kindly review and merge this pull request.