### PR TITLE
chore: edit milkINIT IBC asset info

### DIFF
--- a/testnets/blackwing/assetlist.json
+++ b/testnets/blackwing/assetlist.json
@@ -141,34 +141,6 @@
         "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/tucana/images/TUCANA.png",
         "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/tucana/images/TUCANA.svg"
       }
-    },
-    {
-      "description": "The INIT Liquid Staking Token",
-      "denom_units": [
-        {
-          "denom": "ibc/7F4EE5B281CD4EEF975BD4A892A275D9AB4987BDB70974763A438524631347E5",
-          "exponent": 0
-        },
-        {
-          "denom": "milkINIT",
-          "exponent": 6
-        }
-      ],
-      "base": "ibc/7F4EE5B281CD4EEF975BD4A892A275D9AB4987BDB70974763A438524631347E5",
-      "display": "milkINIT",
-      "name": "INIT Liquid Staking Token",
-      "symbol": "milkINIT",
-      "coingecko_id": "",
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
-          "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
-        }
-      ],
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
-        "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
-      }
     }
   ]
 }

--- a/testnets/blackwing/assetlist.json
+++ b/testnets/blackwing/assetlist.json
@@ -141,6 +141,34 @@
         "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/tucana/images/TUCANA.png",
         "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/tucana/images/TUCANA.svg"
       }
+    },
+    {
+      "description": "MilkyWay IBC bridged milkINIT",
+      "denom_units": [
+        {
+          "denom": "ibc/22D8C3F45607B466D8691E308F9CF86729DAFCBE94BB1FC89F3511FE24E848E2",
+          "exponent": 0
+        },
+        {
+          "denom": "milkINIT",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/22D8C3F45607B466D8691E308F9CF86729DAFCBE94BB1FC89F3511FE24E848E2",
+      "display": "milkINIT",
+      "name": "MilkyWay IBC milkINIT",
+      "symbol": "milkINIT",
+      "coingecko_id": "",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
+          "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
+        "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
+      }
     }
   ]
 }

--- a/testnets/civitia/assetlist.json
+++ b/testnets/civitia/assetlist.json
@@ -29,6 +29,34 @@
         "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/civitia/images/INIT.png",
         "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/civitia/images/INIT.svg"
       }
+    },
+    {
+      "description": "MilkyWay IBC bridged milkINIT",
+      "denom_units": [
+        {
+          "denom": "ibc/22D8C3F45607B466D8691E308F9CF86729DAFCBE94BB1FC89F3511FE24E848E2",
+          "exponent": 0
+        },
+        {
+          "denom": "milkINIT",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/22D8C3F45607B466D8691E308F9CF86729DAFCBE94BB1FC89F3511FE24E848E2",
+      "display": "milkINIT",
+      "name": "MilkyWay IBC milkINIT",
+      "symbol": "milkINIT",
+      "coingecko_id": "",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
+          "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
+        "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
+      }
     }
   ]
 }

--- a/testnets/civitia/assetlist.json
+++ b/testnets/civitia/assetlist.json
@@ -29,34 +29,6 @@
         "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/civitia/images/INIT.png",
         "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/civitia/images/INIT.svg"
       }
-    },
-    {
-      "description": "The INIT Liquid Staking Token",
-      "denom_units": [
-        {
-          "denom": "ibc/7F4EE5B281CD4EEF975BD4A892A275D9AB4987BDB70974763A438524631347E5",
-          "exponent": 0
-        },
-        {
-          "denom": "milkINIT",
-          "exponent": 6
-        }
-      ],
-      "base": "ibc/7F4EE5B281CD4EEF975BD4A892A275D9AB4987BDB70974763A438524631347E5",
-      "display": "milkINIT",
-      "name": "INIT Liquid Staking Token",
-      "symbol": "milkINIT",
-      "coingecko_id": "",
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
-          "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
-        }
-      ],
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
-        "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
-      }
     }
   ]
 }

--- a/testnets/init_ai/assetlist.json
+++ b/testnets/init_ai/assetlist.json
@@ -141,34 +141,6 @@
         "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/tucana/images/TUCANA.png",
         "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/tucana/images/TUCANA.svg"
       }
-    },
-    {
-      "description": "The INIT Liquid Staking Token",
-      "denom_units": [
-        {
-          "denom": "ibc/7F4EE5B281CD4EEF975BD4A892A275D9AB4987BDB70974763A438524631347E5",
-          "exponent": 0
-        },
-        {
-          "denom": "milkINIT",
-          "exponent": 6
-        }
-      ],
-      "base": "ibc/7F4EE5B281CD4EEF975BD4A892A275D9AB4987BDB70974763A438524631347E5",
-      "display": "milkINIT",
-      "name": "INIT Liquid Staking Token",
-      "symbol": "milkINIT",
-      "coingecko_id": "",
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
-          "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
-        }
-      ],
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
-        "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
-      }
     }
   ]
 }

--- a/testnets/init_ai/assetlist.json
+++ b/testnets/init_ai/assetlist.json
@@ -141,6 +141,34 @@
         "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/tucana/images/TUCANA.png",
         "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/tucana/images/TUCANA.svg"
       }
+    },
+    {
+      "description": "MilkyWay IBC bridged milkINIT",
+      "denom_units": [
+        {
+          "denom": "ibc/22D8C3F45607B466D8691E308F9CF86729DAFCBE94BB1FC89F3511FE24E848E2",
+          "exponent": 0
+        },
+        {
+          "denom": "milkINIT",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/22D8C3F45607B466D8691E308F9CF86729DAFCBE94BB1FC89F3511FE24E848E2",
+      "display": "milkINIT",
+      "name": "MilkyWay IBC milkINIT",
+      "symbol": "milkINIT",
+      "coingecko_id": "",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
+          "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
+        "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
+      }
     }
   ]
 }

--- a/testnets/initia/assetlist.json
+++ b/testnets/initia/assetlist.json
@@ -735,6 +735,34 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/initia/images/tucanaINIT-INIT.png"
       }
+    },
+    {
+      "description": "MilkyWay IBC bridged milkINIT",
+      "denom_units": [
+        {
+          "denom": "ibc/26939E676F967B14E319631A9A42233148BBC7F7CEFDCBD347447AF0AE37B1AD",
+          "exponent": 0
+        },
+        {
+          "denom": "milkINIT",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/26939E676F967B14E319631A9A42233148BBC7F7CEFDCBD347447AF0AE37B1AD",
+      "display": "milkINIT",
+      "name": "MilkyWay IBC milkINIT",
+      "symbol": "milkINIT",
+      "coingecko_id": "",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/initia/images/INIT.png",
+          "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/initia/images/INIT.svg"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/initia/images/INIT.png",
+        "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/initia/images/INIT.svg"
+      }
     }
   ]
 }

--- a/testnets/initia/assetlist.json
+++ b/testnets/initia/assetlist.json
@@ -735,34 +735,6 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/initia/images/tucanaINIT-INIT.png"
       }
-    },
-    {
-      "description": "MilkyWay IBC bridged milkINIT",
-      "denom_units": [
-        {
-          "denom": "ibc/26939E676F967B14E319631A9A42233148BBC7F7CEFDCBD347447AF0AE37B1AD",
-          "exponent": 0
-        },
-        {
-          "denom": "milkINIT",
-          "exponent": 6
-        }
-      ],
-      "base": "ibc/26939E676F967B14E319631A9A42233148BBC7F7CEFDCBD347447AF0AE37B1AD",
-      "display": "milkINIT",
-      "name": "MilkyWay IBC milkINIT",
-      "symbol": "milkINIT",
-      "coingecko_id": "",
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/initia/images/INIT.png",
-          "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/initia/images/INIT.svg"
-        }
-      ],
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/initia/images/INIT.png",
-        "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/initia/images/INIT.svg"
-      }
     }
   ]
 }

--- a/testnets/milkyway/assetlist.json
+++ b/testnets/milkyway/assetlist.json
@@ -72,7 +72,7 @@
       ],
       "base": "ibc/37A3FB4FED4CA04ED6D9E5DA36C6D27248645F0E22F585576A1488B8A89C5A50",
       "display": "INIT",
-      "name": "Initia Native Token (IBC)",
+      "name": "Initia IBC INIT",
       "symbol": "INIT",
       "coingecko_id": "",
       "images": [

--- a/testnets/minimove/assetlist.json
+++ b/testnets/minimove/assetlist.json
@@ -141,34 +141,6 @@
         "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/tucana/images/TUCANA.png",
         "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/tucana/images/TUCANA.svg"
       }
-    },
-    {
-      "description": "The INIT Liquid Staking Token",
-      "denom_units": [
-        {
-          "denom": "ibc/7F4EE5B281CD4EEF975BD4A892A275D9AB4987BDB70974763A438524631347E5",
-          "exponent": 0
-        },
-        {
-          "denom": "milkINIT",
-          "exponent": 6
-        }
-      ],
-      "base": "ibc/7F4EE5B281CD4EEF975BD4A892A275D9AB4987BDB70974763A438524631347E5",
-      "display": "milkINIT",
-      "name": "INIT Liquid Staking Token",
-      "symbol": "milkINIT",
-      "coingecko_id": "",
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
-          "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
-        }
-      ],
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
-        "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
-      }
     }
   ]
 }

--- a/testnets/minimove/assetlist.json
+++ b/testnets/minimove/assetlist.json
@@ -141,6 +141,34 @@
         "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/tucana/images/TUCANA.png",
         "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/tucana/images/TUCANA.svg"
       }
+    },
+    {
+      "description": "MilkyWay IBC bridged milkINIT",
+      "denom_units": [
+        {
+          "denom": "ibc/22D8C3F45607B466D8691E308F9CF86729DAFCBE94BB1FC89F3511FE24E848E2",
+          "exponent": 0
+        },
+        {
+          "denom": "milkINIT",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/22D8C3F45607B466D8691E308F9CF86729DAFCBE94BB1FC89F3511FE24E848E2",
+      "display": "milkINIT",
+      "name": "MilkyWay IBC milkINIT",
+      "symbol": "milkINIT",
+      "coingecko_id": "",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
+          "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
+        "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
+      }
     }
   ]
 }

--- a/testnets/miniwasm/assetlist.json
+++ b/testnets/miniwasm/assetlist.json
@@ -141,34 +141,6 @@
         "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/tucana/images/TUCANA.png",
         "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/tucana/images/TUCANA.svg"
       }
-    },
-    {
-      "description": "The INIT Liquid Staking Token",
-      "denom_units": [
-        {
-          "denom": "ibc/7F4EE5B281CD4EEF975BD4A892A275D9AB4987BDB70974763A438524631347E5",
-          "exponent": 0
-        },
-        {
-          "denom": "milkINIT",
-          "exponent": 6
-        }
-      ],
-      "base": "ibc/7F4EE5B281CD4EEF975BD4A892A275D9AB4987BDB70974763A438524631347E5",
-      "display": "milkINIT",
-      "name": "INIT Liquid Staking Token",
-      "symbol": "milkINIT",
-      "coingecko_id": "",
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
-          "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
-        }
-      ],
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
-        "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
-      }
     }
   ]
 }

--- a/testnets/miniwasm/assetlist.json
+++ b/testnets/miniwasm/assetlist.json
@@ -141,6 +141,34 @@
         "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/tucana/images/TUCANA.png",
         "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/tucana/images/TUCANA.svg"
       }
+    },
+    {
+      "description": "MilkyWay IBC bridged milkINIT",
+      "denom_units": [
+        {
+          "denom": "ibc/22D8C3F45607B466D8691E308F9CF86729DAFCBE94BB1FC89F3511FE24E848E2",
+          "exponent": 0
+        },
+        {
+          "denom": "milkINIT",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/22D8C3F45607B466D8691E308F9CF86729DAFCBE94BB1FC89F3511FE24E848E2",
+      "display": "milkINIT",
+      "name": "MilkyWay IBC milkINIT",
+      "symbol": "milkINIT",
+      "coingecko_id": "",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
+          "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
+        "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
+      }
     }
   ]
 }

--- a/testnets/noon/assetlist.json
+++ b/testnets/noon/assetlist.json
@@ -169,34 +169,6 @@
         "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/noon/images/NOON.png",
         "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/noon/images/NOON.svg"
       }
-    },
-    {
-      "description": "The INIT Liquid Staking Token",
-      "denom_units": [
-        {
-          "denom": "ibc/7F4EE5B281CD4EEF975BD4A892A275D9AB4987BDB70974763A438524631347E5",
-          "exponent": 0
-        },
-        {
-          "denom": "milkINIT",
-          "exponent": 6
-        }
-      ],
-      "base": "ibc/7F4EE5B281CD4EEF975BD4A892A275D9AB4987BDB70974763A438524631347E5",
-      "display": "milkINIT",
-      "name": "INIT Liquid Staking Token",
-      "symbol": "milkINIT",
-      "coingecko_id": "",
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
-          "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
-        }
-      ],
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
-        "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
-      }
     }
   ]
 }

--- a/testnets/noon/assetlist.json
+++ b/testnets/noon/assetlist.json
@@ -169,6 +169,34 @@
         "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/noon/images/NOON.png",
         "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/noon/images/NOON.svg"
       }
+    },
+    {
+      "description": "MilkyWay IBC bridged milkINIT",
+      "denom_units": [
+        {
+          "denom": "ibc/22D8C3F45607B466D8691E308F9CF86729DAFCBE94BB1FC89F3511FE24E848E2",
+          "exponent": 0
+        },
+        {
+          "denom": "milkINIT",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/22D8C3F45607B466D8691E308F9CF86729DAFCBE94BB1FC89F3511FE24E848E2",
+      "display": "milkINIT",
+      "name": "MilkyWay IBC milkINIT",
+      "symbol": "milkINIT",
+      "coingecko_id": "",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
+          "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
+        "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
+      }
     }
   ]
 }

--- a/testnets/tucana/assetlist.json
+++ b/testnets/tucana/assetlist.json
@@ -197,6 +197,34 @@
         "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
         "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
       }
+    },
+    {
+      "description": "MilkyWay IBC bridged milkINIT",
+      "denom_units": [
+        {
+          "denom": "ibc/22D8C3F45607B466D8691E308F9CF86729DAFCBE94BB1FC89F3511FE24E848E2",
+          "exponent": 0
+        },
+        {
+          "denom": "milkINIT",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/22D8C3F45607B466D8691E308F9CF86729DAFCBE94BB1FC89F3511FE24E848E2",
+      "display": "milkINIT",
+      "name": "MilkyWay IBC milkINIT",
+      "symbol": "milkINIT",
+      "coingecko_id": "",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/initia/images/INIT.png",
+          "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/initia/images/INIT.svg"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/initia/images/INIT.png",
+        "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/initia/images/INIT.svg"
+      }
     }
   ]
 }

--- a/testnets/tucana/assetlist.json
+++ b/testnets/tucana/assetlist.json
@@ -189,13 +189,13 @@
       "coingecko_id": "",
       "images": [
         {
-          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/initia/images/INIT.png",
-          "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/initia/images/INIT.svg"
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
+          "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
         }
       ],
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/initia/images/INIT.png",
-        "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/initia/images/INIT.svg"
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
+        "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
       }
     }
   ]

--- a/testnets/tucana/assetlist.json
+++ b/testnets/tucana/assetlist.json
@@ -171,34 +171,6 @@
       }
     },
     {
-      "description": "The INIT Liquid Staking Token",
-      "denom_units": [
-        {
-          "denom": "ibc/7F4EE5B281CD4EEF975BD4A892A275D9AB4987BDB70974763A438524631347E5",
-          "exponent": 0
-        },
-        {
-          "denom": "milkINIT",
-          "exponent": 6
-        }
-      ],
-      "base": "ibc/7F4EE5B281CD4EEF975BD4A892A275D9AB4987BDB70974763A438524631347E5",
-      "display": "milkINIT",
-      "name": "INIT Liquid Staking Token",
-      "symbol": "milkINIT",
-      "coingecko_id": "",
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
-          "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
-        }
-      ],
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.png",
-        "svg": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/milkyway/images/milkINIT.svg"
-      }
-    },
-    {
       "description": "MilkyWay IBC bridged milkINIT",
       "denom_units": [
         {


### PR DESCRIPTION
This PR updates the milkINIT IBC denom and information on all chains, by removing wrong denoms and updating the ones that have been tested manually.