### PR TITLE
Modify Noon Testnet fee_tokens order

### DIFF
--- a/testnets/noon/chain.json
+++ b/testnets/noon/chain.json
@@ -14,14 +14,14 @@
   "fees": {
     "fee_tokens": [
       {
-        "denom": "unoon",
+        "denom": "l2/ffea49d63cbadcfd749b4f635eca198b2f3b44cb1f6b580f5d201d58f3bf7aea",
         "fixed_min_gas_price": 0.15,
         "low_gas_price": 0.15,
         "average_gas_price": 0.15,
         "high_gas_price": 0.4
       },
       {
-        "denom": "l2/ffea49d63cbadcfd749b4f635eca198b2f3b44cb1f6b580f5d201d58f3bf7aea",
+        "denom": "unoon",
         "fixed_min_gas_price": 0.15,
         "low_gas_price": 0.15,
         "average_gas_price": 0.15,


### PR DESCRIPTION
[Slack](https://lunchxyz.slack.com/archives/C06FXNFS5B7/p1721221067431239)

Modify the Noon Testnet configuration to set the init token as the default fee token for NOON tokens, as there is no Faucet available.