### PR TITLE
chore: fix channel infos glados-2.1

### DIFF
--- a/testnets/initia/chain.json
+++ b/testnets/initia/chain.json
@@ -165,6 +165,48 @@
         "port_id": "nft-transfer",
         "channel_id": "channel-1",
         "version": "ics721-1"
+      },
+      {
+        "chain_id": "glados-2.1",
+        "port_id": "transfer",
+        "channel_id": "channel-132",
+        "version": "ics20-1"
+      },
+      {
+        "chain_id": "glados-2.1",
+        "port_id": "nft-transfer",
+        "channel_id": "channel-134",
+        "version": "ics721-1"
+      },
+      {
+        "chain_id": "glados-2.1",
+        "port_id": "icahost",
+        "channel_id": "channel-139",
+        "version": "ics20-1"
+      },
+      {
+        "chain_id": "glados-2.1",
+        "port_id": "icahost",
+        "channel_id": "channel-140",
+        "version": "ics20-1"
+      },
+      {
+        "chain_id": "glados-2.1",
+        "port_id": "icahost",
+        "channel_id": "channel-137",
+        "version": "ics20-1"
+      },
+      {
+        "chain_id": "glados-2.1",
+        "port_id": "icahost",
+        "channel_id": "channel-141",
+        "version": "ics20-1"
+      },
+      {
+        "chain_id": "glados-2.1",
+        "port_id": "icahost",
+        "channel_id": "channel-138",
+        "version": "ics20-1"
       }
     ],
     "assetlist": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/initia/assetlist.json"

--- a/testnets/milkyway/chain.json
+++ b/testnets/milkyway/chain.json
@@ -79,50 +79,50 @@
     "op_denoms": [],
     "ibc_channels": [
       {
-        "chain_id": "initiation-1",
+        "chain_id": "initiation-2",
         "port_id": "transfer",
         "channel_id": "channel-0",
         "version": "ics20-1"
       },
       {
-        "chain_id": "initiation-1",
+        "chain_id": "initiation-2",
         "port_id": "wasm.init1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtq7947m6",
         "channel_id": "channel-1",
         "version": "ics721-1"
       },
       {
-        "chain_id": "initiation-1",
-        "port_id": "icacontroller-initiation-1.DELEGATION",
+        "chain_id": "initiation-2",
+        "port_id": "icacontroller-initiation-2.DELEGATION",
         "channel_id": "channel-2",
         "version": "ics20-1"
       },
       {
-        "chain_id": "initiation-1",
-        "port_id": "icacontroller-initiation-1.FEE,",
+        "chain_id": "initiation-2",
+        "port_id": "icacontroller-initiation-2.FEE",
         "channel_id": "channel-3",
         "version": "ics20-1"
       },
       {
-        "chain_id": "initiation-1",
-        "port_id": "icacontroller-initiation-1.WITHDRAWAL",
+        "chain_id": "initiation-2",
+        "port_id": "icacontroller-initiation-2.WITHDRAWAL",
         "channel_id": "channel-4",
         "version": "ics20-1"
       },
       {
-        "chain_id": "initiation-1",
-        "port_id": "icacontroller-initiation-1.REDEMPTION",
+        "chain_id": "initiation-2",
+        "port_id": "icacontroller-initiation-2.REDEMPTION",
         "channel_id": "channel-5",
         "version": "ics20-1"
       },
       {
-        "chain_id": "initiation-1",
-        "port_id": "icacontroller-initiation-1.COMMUNITY_POOL_DEPOSIT",
+        "chain_id": "initiation-2",
+        "port_id": "icacontroller-initiation-2.COMMUNITY_POOL_DEPOSIT",
         "channel_id": "channel-6",
         "version": "ics20-1"
       },
       {
-        "chain_id": "initiation-1",
-        "port_id": "icacontroller-initiation-1.COMMUNITY_POOL_RETURN",
+        "chain_id": "initiation-2",
+        "port_id": "icacontroller-initiation-2.COMMUNITY_POOL_RETURN",
         "channel_id": "channel-7",
         "version": "ics20-1"
       }


### PR DESCRIPTION
## Description

This PR fixes the channels information for the `glados-2.1` MilkyWay testnet, and adds the counterparty information for the `initiation-2` chain.