### PR TITLE
fix: fixed remaining glados-1 scan link in glados 2.1

### DIFF
--- a/testnets/milkyway/chain.json
+++ b/testnets/milkyway/chain.json
@@ -9,23 +9,25 @@
   "bech32_prefix": "init",
   "daemon_name": "milkywayd",
   "node_home": "$HOME/.milkywayd",
-  "key_algos": ["secp256k1"],
+  "key_algos": [
+    "secp256k1"
+  ],
   "slip44": 118,
   "fees": {
     "fee_tokens": [
       {
         "denom": "umilk",
         "fixed_min_gas_price": 0.15,
-        "low_gas_price": 0.2,
-        "average_gas_price": 0.3,
-        "high_gas_price": 0.4
+        "low_gas_price": 0.20,
+        "average_gas_price": 0.30,
+        "high_gas_price": 0.40
       },
       {
         "denom": "ibc/37A3FB4FED4CA04ED6D9E5DA36C6D27248645F0E22F585576A1488B8A89C5A50",
         "fixed_min_gas_price": 0.15,
-        "low_gas_price": 0.2,
-        "average_gas_price": 0.3,
-        "high_gas_price": 0.4
+        "low_gas_price": 0.20,
+        "average_gas_price": 0.30,
+        "high_gas_price": 0.40
       }
     ]
   },

--- a/testnets/milkyway/chain.json
+++ b/testnets/milkyway/chain.json
@@ -9,25 +9,23 @@
   "bech32_prefix": "init",
   "daemon_name": "milkywayd",
   "node_home": "$HOME/.milkywayd",
-  "key_algos": [
-    "secp256k1"
-  ],
+  "key_algos": ["secp256k1"],
   "slip44": 118,
   "fees": {
     "fee_tokens": [
       {
         "denom": "umilk",
         "fixed_min_gas_price": 0.15,
-        "low_gas_price": 0.20,
-        "average_gas_price": 0.30,
-        "high_gas_price": 0.40
+        "low_gas_price": 0.2,
+        "average_gas_price": 0.3,
+        "high_gas_price": 0.4
       },
       {
         "denom": "ibc/37A3FB4FED4CA04ED6D9E5DA36C6D27248645F0E22F585576A1488B8A89C5A50",
         "fixed_min_gas_price": 0.15,
-        "low_gas_price": 0.20,
-        "average_gas_price": 0.30,
-        "high_gas_price": 0.40
+        "low_gas_price": 0.2,
+        "average_gas_price": 0.3,
+        "high_gas_price": 0.4
       }
     ]
   },
@@ -77,8 +75,8 @@
     {
       "kind": "initia scan",
       "url": "https://scan.testnet.initia.xyz/glados-2.1",
-      "tx_page": "https://scan.testnet.initia.xyz/glados-1/txs/${txHash}",
-      "account_page": "https://scan.testnet.initia.xyz/glados-1/accounts/${accountAddress}"
+      "tx_page": "https://scan.testnet.initia.xyz/glados-2.1/txs/${txHash}",
+      "account_page": "https://scan.testnet.initia.xyz/glados-2.1/accounts/${accountAddress}"
     }
   ],
   "faucets": [],


### PR DESCRIPTION
This pull request includes updates to the `testnets/milkyway/chain.json` file to ensure consistency and correctness in the configuration. The most important changes include formatting adjustments and updates to URLs for transaction and account pages.

Configuration updates:

* [`testnets/milkyway/chain.json`](diffhunk://#diff-8298ed96691ff044a1ed46facbb40c1f1c25ec372378c5cb9a7575a0ae98c661L12-R28): Corrected the formatting of `key_algos` and `fees` sections to ensure consistent decimal representation.

URL updates:

* [`testnets/milkyway/chain.json`](diffhunk://#diff-8298ed96691ff044a1ed46facbb40c1f1c25ec372378c5cb9a7575a0ae98c661L80-R79): Updated `tx_page` and `account_page` URLs to reflect the new version `glados-2.1` instead of `glados-1`.