### PR TITLE
fix: Correct typo in test_existsOnChainReg function name

### DIFF
--- a/.github/workflows/utility/test_ibcdata.py
+++ b/.github/workflows/utility/test_ibcdata.py
@@ -70,7 +70,7 @@ def test_chainNameMatchFileNameDevnets(input):
 
 @pytest.mark.parametrize("input", ibcData_files)
     # validates that the chain-name's used exist as root folders on the chain-registry
-def test_existstsOnChainReg(input):
+def test_existsOnChainReg(input):
     pattern = re.compile(r'(.*)-(.*).json$')
     m = pattern.match(input)
     chain1 = m.group(1).lower()


### PR DESCRIPTION
Description:
This commit fixes a typo in the function name `test_existstsOnChainReg`. The function has been renamed to `test_existsOnChainReg` for clarity and consistency. This change improves readability and ensures the function name better reflects its intended purpose. The correction helps maintain consistency with naming conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typo in a test case function name to improve code readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->