### PR TITLE
fix: onyx denom units

### DIFF
--- a/testnets/yominet/assetlist.json
+++ b/testnets/yominet/assetlist.json
@@ -7,6 +7,10 @@
       "denom_units": [
         {
           "denom": "evm/9D9c32921575Fd98e67E27C0189ED4b750Cb17C5",
+          "exponent": 0
+        },
+        {
+          "denom": "ONYX",
           "exponent": 18
         }
       ],


### PR DESCRIPTION
Fix denom units of onyx to display correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new denomination unit "ONYX" with an exponent of 18 for the asset
  - Updated an existing denomination unit with an exponent of 0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->