### PR TITLE
[yominet] update: use LB endpoint

### DIFF
--- a/testnets/yominet/chain.json
+++ b/testnets/yominet/chain.json
@@ -9,12 +9,12 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://maze-rpc-sequencer-9ce4b2ff-e329-459d-8baa-ae49f95f33b2.ane1-prod-nocsm.newmetric.xyz/"
+        "address": "https://rpc.preyominet.initia.tech"
       }
     ],
     "rest": [
       {
-        "address": "https://maze-rest-sequencer-9ce4b2ff-e329-459d-8baa-ae49f95f33b2.ane1-prod-nocsm.newmetric.xyz/"
+        "address": "https://lcd.preyominet-1.initia.tech"
       }
     ],
     "json-rpc": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Update**
	- Updated RPC and REST API addresses for the Yominet testnet
	- New RPC endpoint: `https://rpc.preyominet.initia.tech`
	- New REST API endpoint: `https://lcd.preyominet-1.initia.tech`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->