### PR TITLE
chore: fix grpc port

### DIFF
--- a/testnets/initia/chain.json
+++ b/testnets/initia/chain.json
@@ -152,7 +152,7 @@
     ],
     "grpc": [
       {
-        "address": "grpc.testnet.initia.xyz:9090",
+        "address": "grpc.testnet.initia.xyz:443",
         "provider": "Initia Labs"
       },
       {


### PR DESCRIPTION
fix initiation-2's grpc port to 443 since it's on tls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Update**
	- Updated gRPC connection endpoint for Initia testnet to use secure port 443

<!-- end of auto-generated comment: release notes by coderabbit.ai -->