### PR TITLE
chores: increase svg size limit

### DIFF
--- a/.github/workflows/utility/validate_data.py
+++ b/.github/workflows/utility/validate_data.py
@@ -91,7 +91,7 @@ def validateRawGithubContent(uri: str, isImage: bool):
     raise Exception("file(" + path + ") doesn't exists")
   # check imgae size
   if isImage:
-    sizeLimit = 20 * 1024 if uri.endswith('.svg') else 100 * 1024
+    sizeLimit = 50 * 1024 if uri.endswith('.svg') else 100 * 1024
     size = os.path.getsize(path)
     if size > sizeLimit:
       raise Exception("image(" + path + ") size exceeds limit")

--- a/_api/src/optimizeImages.ts
+++ b/_api/src/optimizeImages.ts
@@ -7,7 +7,7 @@ import { optimize } from "svgo"
 import { getFilePathsInDirectory, getFileSize, isDirectory } from "./utils"
 
 // Constants for image size limits
-const SVG_SIZE_LIMIT = 20 * 1024 // 20KB
+const SVG_SIZE_LIMIT = 50 * 1024 // 50KB
 const PNG_SIZE_LIMIT = 100 * 1024 // 100KB
 const PNG_MAX_HEIGHT = 256 // 256px
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Increased the size limit for SVG image uploads from 20 KB to 50 KB, allowing larger SVG files to be processed successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->