### PR TITLE
fix: fzaar denom

### DIFF
--- a/testnets/zaar/assetlist.json
+++ b/testnets/zaar/assetlist.json
@@ -6,7 +6,7 @@
       "description": "Fake ZAAR Token",
       "denom_units": [
         {
-          "denom": "evm/0x48e68Bed35e199927FF94ECDC34A125C7bfc87e8",
+          "denom": "evm/48e68Bed35e199927FF94ECDC34A125C7bfc87e8",
           "exponent": 0
         },
         {
@@ -16,7 +16,7 @@
       ],
       "type_asset": "erc20",
       "address": "0x48e68Bed35e199927FF94ECDC34A125C7bfc87e8",
-      "base": "evm/0x48e68Bed35e199927FF94ECDC34A125C7bfc87e8",
+      "base": "evm/48e68Bed35e199927FF94ECDC34A125C7bfc87e8",
       "display": "fZAAR",
       "name": "Fake Zaar",
       "symbol": "fZAAR",

--- a/testnets/zaar/chain.json
+++ b/testnets/zaar/chain.json
@@ -14,7 +14,7 @@
   "fees": {
     "fee_tokens": [
       {
-        "denom": "evm/0x48e68Bed35e199927FF94ECDC34A125C7bfc87e8",
+        "denom": "evm/48e68Bed35e199927FF94ECDC34A125C7bfc87e8",
         "fixed_min_gas_price": 15000000000,
         "low_gas_price": 15000000000,
         "average_gas_price": 15000000000,


### PR DESCRIPTION
Fix `fZAAR` cosmos denom 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Zaar testnet configuration files
	- Removed `0x` prefix from hexadecimal addresses in asset and fee token configurations
	- Maintained consistent representation of asset denomination across configuration files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->