### PR TITLE
fix: rename `type` to `category`

### DIFF
--- a/_packages/types/package.json
+++ b/_packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@initia/initia-registry-types",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "The package provides TypeScript type definitions and Zod integration for initia-registry.",
   "types": "./dist/types/index.d.ts",
   "exports": {

--- a/_packages/types/src/types/Profile.ts
+++ b/_packages/types/src/types/Profile.ts
@@ -8,7 +8,7 @@
 export interface ChainProfile {
   name?: string;
   pretty_name?: string;
-  type?: "DeFi" | "NFT" | "Gaming" | "Manage Portfolio";
+  category?: "DeFi" | "NFT" | "Gaming" | "Manage Portfolio";
   tags?: string[];
   /**
    * A longer description for the landing page

--- a/_packages/types/src/zods/Profile.ts
+++ b/_packages/types/src/zods/Profile.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const ProfileSchema = z.object({
   name: z.string().optional(),
   pretty_name: z.string().optional(),
-  type: z.enum(["DeFi", "NFT", "Gaming", "Manage Portfolio"]).optional(),
+  category: z.enum(["DeFi", "NFT", "Gaming", "Manage Portfolio"]).optional(),
   tags: z.array(z.string()).optional(),
   description: z
     .string()

--- a/profile.schema.json
+++ b/profile.schema.json
@@ -9,7 +9,7 @@
     "pretty_name": {
       "type": "string"
     },
-    "type": {
+    "category": {
       "type": "string",
       "enum": ["DeFi", "NFT", "Gaming", "Manage Portfolio"]
     },


### PR DESCRIPTION
- rename `type` to `category`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the package version from 0.0.23 to 0.0.24.
- **Refactor**
  - Renamed the profile property from "type" to "category" while preserving its validation constraints and allowed values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->