### PR TITLE
Fix cosmwasm_path example in chain.schema.json

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -225,7 +225,7 @@
         },
         "cosmwasm_path": {
           "type": "string",
-          "description": "Relative path to the cosmwasm directory. ex. $HOME/.juno/data/wasm",
+          "description": "Relative path to the cosmwasm directory. ex. $HOME/.initia/data/wasm",
           "pattern": "^\\$HOME.*$"
         },
         "ibc_go_version": {
@@ -327,7 +327,7 @@
               },
               "cosmwasm_path": {
                 "type": "string",
-                "description": "Relative path to the cosmwasm directory. ex. $HOME/.juno/data/wasm",
+                "description": "Relative path to the cosmwasm directory. ex. $HOME/.initia/data/wasm",
                 "pattern": "^\\$HOME.*$"
               },
               "ibc_go_version": {


### PR DESCRIPTION
Update cosmwasm_path example from .juno to .initia to match the correct project path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Revised the default guidance for the CosmWasm directory’s location to reflect the updated structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->