### PR TITLE
Fix typo in validateRawGithubContent error message

### DIFF
--- a/.github/workflows/utility/validate_data.py
+++ b/.github/workflows/utility/validate_data.py
@@ -89,7 +89,7 @@ def validateRawGithubContent(uri: str, isImage: bool):
   path = uri[len(prefix):]
   if not os.path.exists(path):
     raise Exception("file(" + path + ") doesn't exists")
-  # check imgae size
+  # check image size
   if isImage:
     sizeLimit = 50 * 1024 if uri.endswith('.svg') else 100 * 1024
     size = os.path.getsize(path)

--- a/.github/workflows/utility/validate_data.py
+++ b/.github/workflows/utility/validate_data.py
@@ -35,7 +35,7 @@ def checkChains():
                         for alias in unit["aliases"]:
                           assetDenoms.append(alias)
                   else:
-                    raise Exception("'denon_units' array doesn't contain any units")
+                    raise Exception("'denom_units' array doesn't contain any units")
                 if "base" in asset:
                   if asset["base"] in assetDenoms:
                     bases.append(asset["base"])


### PR DESCRIPTION
Corrects the typo "imgae" to "image" in the error message in validateRawGithubContent function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error messaging during data validation, ensuring clarity when essential unit information is missing. This update enhances the troubleshooting experience without affecting overall functionality.
	- Corrected a comment for better clarity regarding image size checking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->