### PR TITLE
fix: fix potential issue with assetList type inference

### DIFF
--- a/_packages/initia-registry/README.md
+++ b/_packages/initia-registry/README.md
@@ -14,7 +14,7 @@ Fetch data from initia-registry:
 import { assets, chains, ibc } from "@initia/initia-registry";
 import { Chain } from "@initia/initia-registry-types";
 
-const assetList: Chain = assets.find(
+const assetList: Chain | undefined = assets.find(
   ({ chain_name }) => chain_name === "initia"
 );
 ```


### PR DESCRIPTION
I discovered a potential issue with the type inference in the assetList assignment. The `.find()` method can return either an object or `undefined` if no match is found, so the type of `assetList` should account for both possibilities. Previously, it was inferred as just `Chain`, but it should actually be `Chain | undefined`.  

Here’s the fix:
```typescript
const assetList: Chain | undefined = assets.find(
  ({ chain_name }) => chain_name === "initia"
);
```

This change ensures proper handling of the `undefined` case when no matching asset is found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced handling for cases when an asset isn’t found, improving overall system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->