### PR TITLE
fix: change key-algo to ethsecp256k1

### DIFF
--- a/mainnets/initia/chain.json
+++ b/mainnets/initia/chain.json
@@ -9,7 +9,7 @@
   "bech32_prefix": "init",
   "daemon_name": "initiad",
   "node_home": "$HOME/.initia",
-  "key_algos": ["secp256k1"],
+  "key_algos": ["ethsecp256k1"],
   "slip44": 60,
   "fees": {
     "fee_tokens": [


### PR DESCRIPTION
Use `ethsecp256k1` for key-algo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the blockchain’s cryptographic settings to adopt an Ethereum-compatible algorithm, enhancing alignment with Ethereum standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->