### PR TITLE
chore: add compatible version

### DIFF
--- a/mainnets/initia/chain.json
+++ b/mainnets/initia/chain.json
@@ -31,13 +31,13 @@
   },
   "codebase": {
     "git_repo": "https://github.com/initia-labs/initia",
-    "recommended_version": "v1.0.0-beta.4",
-    "compatible_versions": ["v1.0.0-beta.3", "v1.0.0-beta.4"],
+    "recommended_version": "v1.0.0-beta.5",
+    "compatible_versions": ["v1.0.0-beta.5"],
     "binaries": {
-      "linux/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.4/initia_v1.0.0-beta.4_Linux_x86_64.tar.gz",
-      "linux/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.4/initia_v1.0.0-beta.4_Linux_aarch64.tar.gz",
-      "darwin/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.4/initia_v1.0.0-beta.4_Darwin_x86_64.tar.gz",
-      "darwin/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.4/initia_v1.0.0-beta.4_Darwin_aarch64.tar.gz"
+      "linux/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.5/initia_v1.0.0-beta.5_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.5/initia_v1.0.0-beta.5_Linux_aarch64.tar.gz",
+      "darwin/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.5/initia_v1.0.0-beta.5_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.5/initia_v1.0.0-beta.5_Darwin_aarch64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://rpc.initia.xyz/genesis"

--- a/mainnets/initia/chain.json
+++ b/mainnets/initia/chain.json
@@ -31,13 +31,13 @@
   },
   "codebase": {
     "git_repo": "https://github.com/initia-labs/initia",
-    "recommended_version": "v1.0.0-beta.2",
-    "compatible_versions": ["v1.0.0-beta.1", "v1.0.0-beta.2"],
+    "recommended_version": "v1.0.0-beta.3",
+    "compatible_versions": ["v1.0.0-beta.3"],
     "binaries": {
-      "linux/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.2/initia_v1.0.0-beta.2_Linux_x86_64.tar.gz",
-      "linux/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.2/initia_v1.0.0-beta.2_Linux_aarch64.tar.gz",
-      "darwin/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.2/initia_v1.0.0-beta.2_Darwin_x86_64.tar.gz",
-      "darwin/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.2/initia_v1.0.0-beta.2_Darwin_aarch64.tar.gz"
+      "linux/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.3/initia_v1.0.0-beta.3_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.3/initia_v1.0.0-beta.3_Linux_aarch64.tar.gz",
+      "darwin/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.3/initia_v1.0.0-beta.3_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.3/initia_v1.0.0-beta.3_Darwin_aarch64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://rpc.initia.xyz/genesis"

--- a/mainnets/initia/chain.json
+++ b/mainnets/initia/chain.json
@@ -31,13 +31,13 @@
   },
   "codebase": {
     "git_repo": "https://github.com/initia-labs/initia",
-    "recommended_version": "v1.0.0-beta.1",
-    "compatible_versions": ["v1.0.0-beta.1"],
+    "recommended_version": "v1.0.0-beta.2",
+    "compatible_versions": ["v1.0.0-beta.1", "v1.0.0-beta.2"],
     "binaries": {
-      "linux/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.1/initia_v1.0.0-beta.1_Linux_x86_64.tar.gz",
-      "linux/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.1/initia_v1.0.0-beta.1_Linux_aarch64.tar.gz",
-      "darwin/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.1/initia_v1.0.0-beta.1_Darwin_x86_64.tar.gz",
-      "darwin/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.1/initia_v1.0.0-beta.1_Darwin_aarch64.tar.gz"
+      "linux/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.2/initia_v1.0.0-beta.2_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.2/initia_v1.0.0-beta.2_Linux_aarch64.tar.gz",
+      "darwin/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.2/initia_v1.0.0-beta.2_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.2/initia_v1.0.0-beta.2_Darwin_aarch64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://rpc.initia.xyz/genesis"

--- a/mainnets/initia/chain.json
+++ b/mainnets/initia/chain.json
@@ -31,13 +31,13 @@
   },
   "codebase": {
     "git_repo": "https://github.com/initia-labs/initia",
-    "recommended_version": "v1.0.0-beta.3",
-    "compatible_versions": ["v1.0.0-beta.3"],
+    "recommended_version": "v1.0.0-beta.4",
+    "compatible_versions": ["v1.0.0-beta.3", "v1.0.0-beta.4"],
     "binaries": {
-      "linux/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.3/initia_v1.0.0-beta.3_Linux_x86_64.tar.gz",
-      "linux/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.3/initia_v1.0.0-beta.3_Linux_aarch64.tar.gz",
-      "darwin/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.3/initia_v1.0.0-beta.3_Darwin_x86_64.tar.gz",
-      "darwin/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.3/initia_v1.0.0-beta.3_Darwin_aarch64.tar.gz"
+      "linux/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.4/initia_v1.0.0-beta.4_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.4/initia_v1.0.0-beta.4_Linux_aarch64.tar.gz",
+      "darwin/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.4/initia_v1.0.0-beta.4_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.4/initia_v1.0.0-beta.4_Darwin_aarch64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://rpc.initia.xyz/genesis"

--- a/mainnets/initia/chain.json
+++ b/mainnets/initia/chain.json
@@ -31,13 +31,13 @@
   },
   "codebase": {
     "git_repo": "https://github.com/initia-labs/initia",
-    "recommended_version": "v1.0.0-beta.5",
-    "compatible_versions": ["v1.0.0-beta.5"],
+    "recommended_version": "v1.0.0-beta.6",
+    "compatible_versions": ["v1.0.0-beta.6"],
     "binaries": {
-      "linux/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.5/initia_v1.0.0-beta.5_Linux_x86_64.tar.gz",
-      "linux/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.5/initia_v1.0.0-beta.5_Linux_aarch64.tar.gz",
-      "darwin/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.5/initia_v1.0.0-beta.5_Darwin_x86_64.tar.gz",
-      "darwin/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.5/initia_v1.0.0-beta.5_Darwin_aarch64.tar.gz"
+      "linux/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.6/initia_v1.0.0-beta.6_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.6/initia_v1.0.0-beta.6_Linux_aarch64.tar.gz",
+      "darwin/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.6/initia_v1.0.0-beta.6_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.6/initia_v1.0.0-beta.6_Darwin_aarch64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://rpc.initia.xyz/genesis"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the release version to v1.0.0-beta.6.
  - Adjusted compatibility to support only the new beta release v1.0.0-beta.6.
  - Refreshed download links for binaries across all supported platforms to ensure users receive the correct release version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->