### PR TITLE
(api) Include `slip44` on aggregate `chains.json`

### DIFF
--- a/_api/package.json
+++ b/_api/package.json
@@ -6,10 +6,12 @@
   "devDependencies": {
     "@initia/initia-registry-types": "^0.0.22",
     "@tsconfig/recommended": "^1.0.8",
+    "@types/lodash": "^4.17.16",
     "@types/node": "^22.13.1",
     "@types/ramda": "^0.30.2",
     "@types/uuid": "^10.0.0",
     "chalk": "^5.4.1",
+    "lodash": "^4.17.21",
     "ramda": "^0.30.1",
     "sharp": "^0.33.5",
     "svgo": "^3.3.2",

--- a/_api/pnpm-lock.yaml
+++ b/_api/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@tsconfig/recommended':
         specifier: ^1.0.8
         version: 1.0.8
+      '@types/lodash':
+        specifier: ^4.17.16
+        version: 4.17.16
       '@types/node':
         specifier: ^22.13.1
         version: 22.13.1
@@ -26,6 +29,9 @@ importers:
       chalk:
         specifier: ^5.4.1
         version: 5.4.1
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
       ramda:
         specifier: ^0.30.1
         version: 0.30.1
@@ -306,6 +312,9 @@ packages:
   '@tsconfig/recommended@1.0.8':
     resolution: {integrity: sha512-TotjFaaXveVUdsrXCdalyF6E5RyG6+7hHHQVZonQtdlk1rJZ1myDIvPUUKPhoYv+JAzThb2lQJh9+9ZfF46hsA==}
 
+  '@types/lodash@4.17.16':
+    resolution: {integrity: sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==}
+
   '@types/node@22.13.1':
     resolution: {integrity: sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==}
 
@@ -395,6 +404,9 @@ packages:
 
   is-arrayish@0.3.2:
     resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   mdn-data@2.0.28:
     resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
@@ -621,6 +633,8 @@ snapshots:
 
   '@tsconfig/recommended@1.0.8': {}
 
+  '@types/lodash@4.17.16': {}
+
   '@types/node@22.13.1':
     dependencies:
       undici-types: 6.20.0
@@ -734,6 +748,8 @@ snapshots:
       resolve-pkg-maps: 1.0.0
 
   is-arrayish@0.3.2: {}
+
+  lodash@4.17.21: {}
 
   mdn-data@2.0.28: {}
 

--- a/_api/src/aggregateChains.ts
+++ b/_api/src/aggregateChains.ts
@@ -14,6 +14,7 @@ const selectedChainProperties: (keyof Chain)[] = [
   "faucets",
   "metadata",
   "logo_URIs",
+  "slip44",
   "bech32_prefix",
   "network_type",
   "evm_chain_id",

--- a/_api/src/main.ts
+++ b/_api/src/main.ts
@@ -8,7 +8,7 @@ import { optimizeImages } from "./optimizeImages"
 const __filename = url.fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
-const rootDir = process.env.NETWORK_DIR || ""
+const rootDir = process.env.NETWORK_DIR || "mainnets"
 const srcDir = path.resolve(__dirname, "../..", rootDir)
 const distDir = path.resolve(__dirname, "../dist")
 

--- a/_api/src/replaceUrls.ts
+++ b/_api/src/replaceUrls.ts
@@ -1,4 +1,5 @@
 import { mapObjIndexed, replace } from "ramda"
+import escapeRegExp from "lodash/fp/escapeRegExp"
 import { getFilePathsInDirectory, isDirectory, readJsonFile, writeJsonFile } from "./utils"
 
 // Creates a URL replacer function based on the given network type
@@ -11,7 +12,9 @@ export function createUrlReplacer(rootDir: string) {
     rehearsal: "https://registry.rehearsal.initia.xyz",
   }
 
-  const regex = new RegExp(`https:\/\/raw\.githubusercontent\.com\/initia-labs\/initia-registry\/main\/${rootDir}`)
+  const regex = new RegExp(
+    `https:\/\/raw\.githubusercontent\.com\/initia-labs\/initia-registry\/main\/${escapeRegExp(rootDir)}`
+  )
   const baseUrl = baseUrls[rootDir || "mainnets"]
   return replace(regex, baseUrl)
 }

--- a/_api/src/replaceUrls.ts
+++ b/_api/src/replaceUrls.ts
@@ -13,7 +13,7 @@ export function createUrlReplacer(rootDir: string) {
   }
 
   const regex = new RegExp(
-    `https:\/\/raw\.githubusercontent\.com\/initia-labs\/initia-registry\/main\/${escapeRegExp(rootDir)}`
+    escapeRegExp(`https:\/\/raw\.githubusercontent\.com\/initia-labs\/initia-registry\/main\/${rootDir}`)
   )
   const baseUrl = baseUrls[rootDir || "mainnets"]
   return replace(regex, baseUrl)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced chain data selection by expanding available properties for a more complete view.
  - Updated the default network directory, ensuring improved and consistent configuration handling when no custom setting is provided.
  - Improved URL matching process by enhancing the handling of special characters in the directory path.

- **Chores**
  - Added new development dependencies: `@types/lodash` and `lodash`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->