### PR TITLE
chore: bump mainnet initia version

### DIFF
--- a/mainnets/initia/chain.json
+++ b/mainnets/initia/chain.json
@@ -31,13 +31,13 @@
   },
   "codebase": {
     "git_repo": "https://github.com/initia-labs/initia",
-    "recommended_version": "v1.0.0-beta.6",
-    "compatible_versions": ["v1.0.0-beta.6"],
+    "recommended_version": "v1.0.0-beta.7",
+    "compatible_versions": ["v1.0.0-beta.7"],
     "binaries": {
-      "linux/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.6/initia_v1.0.0-beta.6_Linux_x86_64.tar.gz",
-      "linux/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.6/initia_v1.0.0-beta.6_Linux_aarch64.tar.gz",
-      "darwin/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.6/initia_v1.0.0-beta.6_Darwin_x86_64.tar.gz",
-      "darwin/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.6/initia_v1.0.0-beta.6_Darwin_aarch64.tar.gz"
+      "linux/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.7/initia_v1.0.0-beta.7_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.7/initia_v1.0.0-beta.7_Linux_aarch64.tar.gz",
+      "darwin/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.7/initia_v1.0.0-beta.7_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-beta.7/initia_v1.0.0-beta.7_Darwin_aarch64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://rpc.initia.xyz/genesis"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the software version to **v1.0.0-beta.7**.
  - Refreshed download links for Linux and Darwin binaries to align with the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->