### PR TITLE
Fix traverseFiles to only process files, not directories

### DIFF
--- a/_api/src/traverseFiles.ts
+++ b/_api/src/traverseFiles.ts
@@ -17,9 +17,9 @@ export function traverseFiles(folderPath: string, callback: (filePath: string) =
     if (isDirectory(fullPath)) {
       // If the entry is a directory, recursively traverse it
       traverseFiles(fullPath, callback)
+    } else {
+      // Execute the callback only for files
+      callback(fullPath)
     }
-
-    // Execute the callback
-    callback(fullPath)
   }
 }


### PR DESCRIPTION
Fixed a logical error in traverseFiles.ts where the callback function was executed for both files and directories. 

The function now correctly processes only files, as suggested by its name and documentation. 

This prevents potential errors in JSON processing and image optimization that rely on this utility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated file scanning so operations now target only file entries while directories are traversed without triggering actions.
  - This change enhances system accuracy and efficiency, ensuring only relevant items are processed.
  - The streamlined behavior reduces unnecessary processing and contributes to a smoother overall file handling experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->