### PR TITLE
feat: update initiation-2 to use v1.0.0-rc.1

### DIFF
--- a/testnets/initia/chain.json
+++ b/testnets/initia/chain.json
@@ -31,13 +31,13 @@
   },
   "codebase": {
     "git_repo": "https://github.com/initia-labs/initia",
-    "recommended_version": "v1.0.0-rc.0",
-    "compatible_versions": ["v1.0.0-rc.0"],
+    "recommended_version": "v1.0.0-rc.1",
+    "compatible_versions": ["v1.0.0-rc.1", "v1.0.0-rc.0"],
     "binaries": {
-      "linux/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-rc.0/initia_v1.0.0-rc.0_Linux_x86_64.tar.gz",
-      "linux/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-rc.0/initia_v1.0.0-rc.0_Linux_aarch64.tar.gz",
-      "darwin/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-rc.0/initia_v1.0.0-rc.0_Darwin_x86_64.tar.gz",
-      "darwin/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-rc.0/initia_v1.0.0-rc.0_Darwin_aarch64.tar.gz"
+      "linux/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-rc.1/initia_v1.0.0-rc.1_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-rc.1/initia_v1.0.0-rc.1_Linux_aarch64.tar.gz",
+      "darwin/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-rc.1/initia_v1.0.0-rc.1_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-rc.1/initia_v1.0.0-rc.1_Darwin_aarch64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://storage.googleapis.com/init-common-genesis/initiation-2/genesis.json"
@@ -94,13 +94,13 @@
       },
       {
         "name": "v1.0.0-rc.0",
-        "compatible_versions": ["v1.0.0-rc.0"],
+        "compatible_versions": ["v1.0.0-rc.1", "v1.0.0-rc.0"],
         "height": 7200000,
         "binaries": {
-          "linux/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-rc.0/initia_v1.0.0-rc.0_Linux_x86_64.tar.gz",
-          "linux/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-rc.0/initia_v1.0.0-rc.0_Linux_aarch64.tar.gz",
-          "darwin/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-rc.0/initia_v1.0.0-rc.0_Darwin_x86_64.tar.gz",
-          "darwin/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-rc.0/initia_v1.0.0-rc.0_Darwin_aarch64.tar.gz"
+          "linux/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-rc.1/initia_v1.0.0-rc.1_Linux_x86_64.tar.gz",
+          "linux/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-rc.1/initia_v1.0.0-rc.1_Linux_aarch64.tar.gz",
+          "darwin/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-rc.1/initia_v1.0.0-rc.1_Darwin_x86_64.tar.gz",
+          "darwin/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0-rc.1/initia_v1.0.0-rc.1_Darwin_aarch64.tar.gz"
         }
       }
     ]

--- a/testnets/minievm/chain.json
+++ b/testnets/minievm/chain.json
@@ -28,13 +28,13 @@
   },
   "codebase": {
     "git_repo": "https://github.com/initia-labs/minievm",
-    "recommended_version": "v0.6.10-1",
-    "compatible_versions": ["v0.6.10"],
+    "recommended_version": "v1.0.0-rc.0",
+    "compatible_versions": ["v1.0.0-rc.0"],
     "binaries": {
-      "linux/amd64": "https://github.com/initia-labs/minievm/releases/download/v0.6.10-1/minievm_v0.6.10-1_Linux_x86_64.tar.gz",
-      "linux/arm64": "https://github.com/initia-labs/minievm/releases/download/v0.6.10-1/minievm_v0.6.10-1_Linux_aarch64.tar.gz",
-      "darwin/amd64": "https://github.com/initia-labs/minievm/releases/download/v0.6.10-1/minievm_v0.6.10-1_Darwin_x86_64.tar.gz",
-      "darwin/arm64": "https://github.com/initia-labs/minievm/releases/download/v0.6.10-1/minievm_v0.6.10-1_Darwin_aarch64.tar.gz"
+      "linux/amd64": "https://github.com/initia-labs/minievm/releases/download/v1.0.0-rc.0/minievm_v1.0.0-rc.0_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/initia-labs/minievm/releases/download/v1.0.0-rc.0/minievm_v1.0.0-rc.0_Linux_aarch64.tar.gz",
+      "darwin/amd64": "https://github.com/initia-labs/minievm/releases/download/v1.0.0-rc.0/minievm_v1.0.0-rc.0_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/initia-labs/minievm/releases/download/v1.0.0-rc.0/minievm_v1.0.0-rc.0_Darwin_aarch64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://storage.googleapis.com/init-common-genesis/minievm-2/genesis.json"
@@ -158,6 +158,18 @@
           "linux/arm64": "https://github.com/initia-labs/minievm/releases/download/v0.6.10-1/minievm_v0.6.10-1_Linux_aarch64.tar.gz",
           "darwin/amd64": "https://github.com/initia-labs/minievm/releases/download/v0.6.10-1/minievm_v0.6.10-1_Darwin_x86_64.tar.gz",
           "darwin/arm64": "https://github.com/initia-labs/minievm/releases/download/v0.6.10-1/minievm_v0.6.10-1_Darwin_aarch64.tar.gz"
+        }
+      },
+      {
+        "name": "v1.0.0-rc.0",
+        "recommended_version": "v1.0.0-rc.0",
+        "compatible_versions": ["v1.0.0-rc.0"],
+        "height": 7424440,
+        "binaries": {
+          "linux/amd64": "https://github.com/initia-labs/minievm/releases/download/v1.0.0-rc.0/minievm_v1.0.0-rc.0_Linux_x86_64.tar.gz",
+          "linux/arm64": "https://github.com/initia-labs/minievm/releases/download/v1.0.0-rc.0/minievm_v1.0.0-rc.0_Linux_aarch64.tar.gz",
+          "darwin/amd64": "https://github.com/initia-labs/minievm/releases/download/v1.0.0-rc.0/minievm_v1.0.0-rc.0_Darwin_x86_64.tar.gz",
+          "darwin/arm64": "https://github.com/initia-labs/minievm/releases/download/v1.0.0-rc.0/minievm_v1.0.0-rc.0_Darwin_aarch64.tar.gz"
         }
       }
     ]

--- a/testnets/minimove/chain.json
+++ b/testnets/minimove/chain.json
@@ -27,13 +27,13 @@
   },
   "codebase": {
     "git_repo": "https://github.com/initia-labs/minimove",
-    "recommended_version": "v0.6.5",
-    "compatible_versions": ["v0.6.5"],
+    "recommended_version": "v1.0.0-rc.0",
+    "compatible_versions": ["v1.0.0-rc.0"],
     "binaries": {
-      "linux/amd64": "https://github.com/initia-labs/minimove/releases/download/v0.6.5/minimove_v0.6.5_Linux_x86_64.tar.gz",
-      "linux/arm64": "https://github.com/initia-labs/minimove/releases/download/v0.6.5/minimove_v0.6.5_Linux_aarch64.tar.gz",
-      "darwin/amd64": "https://github.com/initia-labs/minimove/releases/download/v0.6.5/minimove_v0.6.5_Darwin_x86_64.tar.gz",
-      "darwin/arm64": "https://github.com/initia-labs/minimove/releases/download/v0.6.5/minimove_v0.6.5_Darwin_aarch64.tar.gz"
+      "linux/amd64": "https://github.com/initia-labs/minimove/releases/download/v1.0.0-rc.0/minimove_v1.0.0-rc.0_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/initia-labs/minimove/releases/download/v1.0.0-rc.0/minimove_v1.0.0-rc.0_Linux_aarch64.tar.gz",
+      "darwin/amd64": "https://github.com/initia-labs/minimove/releases/download/v1.0.0-rc.0/minimove_v1.0.0-rc.0_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/initia-labs/minimove/releases/download/v1.0.0-rc.0/minimove_v1.0.0-rc.0_Darwin_aarch64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://storage.googleapis.com/init-common-genesis/minimove-2/genesis.json"
@@ -97,6 +97,18 @@
           "linux/arm64": "https://github.com/initia-labs/minimove/releases/download/v0.6.5/minimove_v0.6.5_Linux_aarch64.tar.gz",
           "darwin/amd64": "https://github.com/initia-labs/minimove/releases/download/v0.6.5/minimove_v0.6.5_Darwin_x86_64.tar.gz",
           "darwin/arm64": "https://github.com/initia-labs/minimove/releases/download/v0.6.5/minimove_v0.6.5_Darwin_aarch64.tar.gz"
+        }
+      },
+      {
+        "name": "v1.0.0-rc.0",
+        "recommended_version": "v1.0.0-rc.0",
+        "compatible_versions": ["v1.0.0-rc.0"],
+        "height": 8058030,
+        "binaries": {
+          "linux/amd64": "https://github.com/initia-labs/minimove/releases/download/v1.0.0-rc.0/minimove_v1.0.0-rc.0_Linux_x86_64.tar.gz",
+          "linux/arm64": "https://github.com/initia-labs/minimove/releases/download/v1.0.0-rc.0/minimove_v1.0.0-rc.0_Linux_aarch64.tar.gz",
+          "darwin/amd64": "https://github.com/initia-labs/minimove/releases/download/v1.0.0-rc.0/minimove_v1.0.0-rc.0_Darwin_x86_64.tar.gz",
+          "darwin/arm64": "https://github.com/initia-labs/minimove/releases/download/v1.0.0-rc.0/minimove_v1.0.0-rc.0_Darwin_aarch64.tar.gz"
         }
       }
     ]

--- a/testnets/miniwasm/chain.json
+++ b/testnets/miniwasm/chain.json
@@ -27,13 +27,13 @@
   },
   "codebase": {
     "git_repo": "https://github.com/initia-labs/miniwasm",
-    "recommended_version": "v0.6.4",
-    "compatible_versions": ["v0.6.4"],
+    "recommended_version": "v1.0.0-rc.0",
+    "compatible_versions": ["v1.0.0-rc.0"],
     "binaries": {
-      "linux/amd64": "https://github.com/initia-labs/miniwasm/releases/download/v0.6.4/miniwasm_v0.6.4_Linux_x86_64.tar.gz",
-      "linux/arm64": "https://github.com/initia-labs/miniwasm/releases/download/v0.6.4/miniwasm_v0.6.4_Linux_aarch64.tar.gz",
-      "darwin/amd64": "https://github.com/initia-labs/miniwasm/releases/download/v0.6.4/miniwasm_v0.6.4_Darwin_x86_64.tar.gz",
-      "darwin/arm64": "https://github.com/initia-labs/miniwasm/releases/download/v0.6.4/miniwasm_v0.6.4_Darwin_aarch64.tar.gz"
+      "linux/amd64": "https://github.com/initia-labs/miniwasm/releases/download/v1.0.0-rc.0/miniwasm_v1.0.0-rc.0_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/initia-labs/miniwasm/releases/download/v1.0.0-rc.0/miniwasm_v1.0.0-rc.0_Linux_aarch64.tar.gz",
+      "darwin/amd64": "https://github.com/initia-labs/miniwasm/releases/download/v1.0.0-rc.0/miniwasm_v1.0.0-rc.0_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/initia-labs/miniwasm/releases/download/v1.0.0-rc.0/miniwasm_v1.0.0-rc.0_Darwin_aarch64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://storage.googleapis.com/init-common-genesis/miniwasm-2/genesis.json"
@@ -73,6 +73,18 @@
           "linux/arm64": "https://github.com/initia-labs/miniwasm/releases/download/v0.6.4/miniwasm_v0.6.4_Linux_aarch64.tar.gz",
           "darwin/amd64": "https://github.com/initia-labs/miniwasm/releases/download/v0.6.4/miniwasm_v0.6.4_Darwin_x86_64.tar.gz",
           "darwin/arm64": "https://github.com/initia-labs/miniwasm/releases/download/v0.6.4/miniwasm_v0.6.4_Darwin_aarch64.tar.gz"
+        }
+      },
+      {
+        "name": "v1.0.0-rc.0",
+        "recommended_version": "v1.0.0-rc.0",
+        "compatible_versions": ["v1.0.0-rc.0"],
+        "height": 8195100,
+        "binaries": {
+          "linux/amd64": "https://github.com/initia-labs/miniwasm/releases/download/v1.0.0-rc.0/miniwasm_v1.0.0-rc.0_Linux_x86_64.tar.gz",
+          "linux/arm64": "https://github.com/initia-labs/miniwasm/releases/download/v1.0.0-rc.0/miniwasm_v1.0.0-rc.0_Linux_aarch64.tar.gz",
+          "darwin/amd64": "https://github.com/initia-labs/miniwasm/releases/download/v1.0.0-rc.0/miniwasm_v1.0.0-rc.0_Darwin_x86_64.tar.gz",
+          "darwin/arm64": "https://github.com/initia-labs/miniwasm/releases/download/v1.0.0-rc.0/miniwasm_v1.0.0-rc.0_Darwin_aarch64.tar.gz"
         }
       }
     ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the recommended release candidate to **v1.0.0-rc.0**.
	- Refreshed download links for Linux and macOS binaries to reflect the new version.
	- Ensured backward compatibility by supporting both **v1.0.0-rc.0** and the previous version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->