### PR TITLE
fix: replace minitia in readme with rollup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The Initia Registry serves as a central repository containing crucial metadata f
 It houses configuration files such as ```chain.json``` and ```assetlist.json```, which are vital for initiating and interacting with nodes, as well as understanding the available assets on each chain. The registry also includes ```profile.json``` files, which provide users with a comprehensive overview of each chain, including its category, description, and status.
 Additionally, the registry includes ```*.schema.json``` files in the root directory, outlining the recommended metadata structure. These schemas are dynamic, subject to revisions based on evolving user needs, and may include optional fields beyond the current schema specifications.
 
-## Adding Minitia to Initia Registry
+## Adding a Rollup to Initia Registry
 
 1. **Fork the Repository**: Begin by forking the repository where the Initia Registry is hosted.
 2. **Add a New Directory**: Create a directory named after the chain you intend to add.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the registry instructions header to now encompass the addition of any rollup rather than focusing solely on a specific service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->