### PR TITLE
update gas price

### DIFF
--- a/testnets/culinaris/chain.json
+++ b/testnets/culinaris/chain.json
@@ -15,11 +15,11 @@
   "fees": {
     "fee_tokens": [
       {
-        "denom": "umin",
-        "fixed_min_gas_price": 0,
-        "low_gas_price": 0,
-        "average_gas_price": 0,
-        "high_gas_price": 0
+        "denom": "l2/83db4af0de8965c851672915eaa857f0911385f7d71f9da1decb2504d3d3ffdd",
+        "fixed_min_gas_price": 0.015,
+        "low_gas_price": 0.015,
+        "average_gas_price": 0.015,
+        "high_gas_price": 0.04
       }
     ]
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the network fee structure by replacing the previous fee token with a new token.
	- Adjusted transaction fee settings with updated gas price tiers, setting the minimum, low, and average fees to 0.015 and the higher fee to 0.04, reflecting a streamlined fee calculation model for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->