### PR TITLE
add nuwa rollup

### DIFF
--- a/testnets/initia/chain.json
+++ b/testnets/initia/chain.json
@@ -318,6 +318,18 @@
         "port_id": "nft-transfer",
         "channel_id": "channel-1318",
         "version": "ics721-1"
+      },
+      {
+        "chain_id": "nuwa-rollup-1",
+        "port_id": "transfer",
+        "channel_id": "channel-2453",
+        "version": "ics20-1"
+      },
+      {
+        "chain_id": "nuwa-rollup-1",
+        "port_id": "nft-transfer",
+        "channel_id": "channel-2454",
+        "version": "ics721-1"
       }
     ],
     "assetlist": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/initia/assetlist.json"

--- a/testnets/nuwarollup/assetlist.json
+++ b/testnets/nuwarollup/assetlist.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "../../assetlist.schema.json",
+  "chain_name": "nuwarollup",
+  "assets": [
+    {
+      "description": "The native token of Initia",
+      "denom_units": [
+        {
+          "denom": "l2/6df67ba2b8890ef45c525bdccac4d69e48502e9ee482fac8cc6eb9036c2fb364",
+          "exponent": 0
+        },
+        {
+          "denom": "INIT",
+          "exponent": 6
+        }
+      ],
+      "base": "l2/6df67ba2b8890ef45c525bdccac4d69e48502e9ee482fac8cc6eb9036c2fb364",
+      "display": "INIT",
+      "traces": [
+        {
+          "type": "op",
+          "counterparty": {
+            "base_denom": "uinit",
+            "chain_name": "initia"
+          },
+          "chain": {
+            "bridge_id": "1152"
+          }
+        }
+      ],
+      "name": "Initia Native Token",
+      "symbol": "INIT",
+      "coingecko_id": "",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
+      }
+    }
+  ]
+}

--- a/testnets/nuwarollup/chain.json
+++ b/testnets/nuwarollup/chain.json
@@ -49,11 +49,11 @@
   },
   "images": [
     {
-      "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/nuwarollup/images/rena.png"
+      "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/rena.png"
     }
   ],
   "logo_URIs": {
-    "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/nuwarollup/images/rena.png"
+    "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/rena.png"
   },
   "metadata": {
     "op_bridge_id": "1152",

--- a/testnets/nuwarollup/chain.json
+++ b/testnets/nuwarollup/chain.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "../../chain.schema.json",
+  "chain_name": "nuwarollup",
+  "pretty_name": "Nuwa",
+  "chain_id": "nuwa-rollup-1",
+  "bech32_prefix": "init",
+  "network_type": "testnet",
+  "codebase": {
+    "git_repo": "https://github.com/initia-labs/minimove",
+    "recommended_version": "v1.0.0-rc.0",
+    "binaries": {
+      "linux/amd64": "https://github.com/initia-labs/minimove/releases/download/v1.0.0-rc.0/minimove_v1.0.0-rc.0_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/initia-labs/minimove/releases/download/v1.0.0-rc.0/minimove_v1.0.0-rc.0_Linux_aarch64.tar.gz",
+      "darwin/amd64": "https://github.com/initia-labs/minimove/releases/download/v1.0.0-rc.0/minimove_v1.0.0-rc.0_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/initia-labs/minimove/releases/download/v1.0.0-rc.0/minimove_v1.0.0-rc.0_Darwin_aarch64.tar.gz"
+    },
+    "genesis": {
+      "genesis_url": "https://rpc-nuwa-rollup-1.anvil.asia-southeast.initia.xyz/genesis"
+    }
+  },
+  "apis": {
+    "rpc": [
+      {
+        "address": "https://rpc-nuwa-rollup-1.anvil.asia-southeast.initia.xyz"
+      }
+    ],
+    "rest": [
+      {
+        "address": "https://rest-nuwa-rollup-1.anvil.asia-southeast.initia.xyz"
+      }
+    ],
+    "grpc": [
+      {
+        "address": "grpc-nuwa-rollup-1.anvil.asia-southeast.initia.xyz:443"
+      }
+    ]
+  },
+  "key_algos": [
+    "secp256k1"
+  ],
+  "slip44": 118,
+  "fees": {
+    "fee_tokens": [
+      {
+        "denom": "l2/6df67ba2b8890ef45c525bdccac4d69e48502e9ee482fac8cc6eb9036c2fb364",
+        "fixed_min_gas_price": 0.01
+      }
+    ]
+  },
+  "images": [
+    {
+      "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/nuwarollup/images/rena.png"
+    }
+  ],
+  "logo_URIs": {
+    "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/nuwarollup/images/rena.png"
+  },
+  "metadata": {
+    "op_bridge_id": "1152",
+    "op_denoms": [
+      "uinit"
+    ],
+    "executor_uri": "https://opinit-api-nuwa-rollup-1.anvil.asia-southeast.initia.xyz",
+    "ibc_channels": [
+      {
+        "chain_id": "initiation-2",
+        "port_id": "nft-transfer",
+        "channel_id": "channel-1",
+        "version": "ics721-1"
+      },
+      {
+        "chain_id": "initiation-2",
+        "port_id": "transfer",
+        "channel_id": "channel-0",
+        "version": "ics20-1"
+      }
+    ],
+    "assetlist": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/nuwarollup/assetlist.json",
+    "minitia": {
+      "type": "minimove",
+      "version": "v1.0.0-rc.0"
+    }
+  }
+}


### PR DESCRIPTION
- add nuwa rollup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configuration and asset list files for the "nuwarollup" testnet, including support for the "Initia Native Token" and detailed chain metadata.
  - Enabled IBC channels for both token and NFT transfers between "initia" and "nuwa-rollup-1" testnets.

- **Chores**
  - Updated metadata to include new IBC channel entries for enhanced cross-chain interoperability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->