### PR TITLE
fix(mainnet)/update-eth-denom

### DIFF
--- a/mainnets/initia/assetlist.json
+++ b/mainnets/initia/assetlist.json
@@ -152,7 +152,7 @@
       "description": "ETH token",
       "denom_units": [
         {
-          "denom": "move/c3b42c557c243205835971567f9516c78208f342023cf1c0c15ed8f3d3a6a271",
+          "denom": "move/8e263c29f0e30feb33bae5b284a601f8fe7f94965ef2d2662abf773fc851aa83",
           "exponent": 0
         },
         {
@@ -160,7 +160,7 @@
           "exponent": 6
         }
       ],
-      "base": "move/c3b42c557c243205835971567f9516c78208f342023cf1c0c15ed8f3d3a6a271",
+      "base": "move/8e263c29f0e30feb33bae5b284a601f8fe7f94965ef2d2662abf773fc851aa83",
       "display": "ETH",
       "name": "ETH Token",
       "symbol": "ETH",


### PR DESCRIPTION
* use stargaze ETH: https://layerzeroscan.com/tx/0xaf5a1b868001013971178bd27dd099cb8a5d460bdae5474d34d88bd83bd0515f
* https://scan.initia.xyz/interwoven-1/txs/D37A48438D77850A1543D4A92C9DD4DD86373CB930882CA71C70BC74A4B34CFE
[3:05](https://initia-labs.slack.com/archives/D06CFT8TEN5/p1745215556515029)

DENOM: `move/8e263c29f0e30feb33bae5b284a601f8fe7f94965ef2d2662abf773fc851aa83`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the ETH token information for the Initia chain with a new identifier. No visible changes to token name, symbol, or appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->