### PR TITLE
add mainnet rollups

### DIFF
--- a/mainnets/civitia/assetlist.json
+++ b/mainnets/civitia/assetlist.json
@@ -33,11 +33,11 @@
       "coingecko_id": "",
       "images": [
         {
-          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/mainnets/initia/images/INIT.png"
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
         }
       ],
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/mainnets/initia/images/INIT.png"
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
       }
     }
   ]

--- a/mainnets/civitia/assetlist.json
+++ b/mainnets/civitia/assetlist.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "../../assetlist.schema.json",
+  "chain_name": "civitia",
+  "assets": [
+    {
+      "description": "The native token of Initia",
+      "denom_units": [
+        {
+          "denom": "l2/2b2d36f666e98b9eecf70d6ec24b882b79f2c8e2af73f54f97b8b670dbb87605",
+          "exponent": 0
+        },
+        {
+          "denom": "INIT",
+          "exponent": 6
+        }
+      ],
+      "base": "l2/2b2d36f666e98b9eecf70d6ec24b882b79f2c8e2af73f54f97b8b670dbb87605",
+      "display": "INIT",
+      "traces": [
+        {
+          "type": "op",
+          "counterparty": {
+            "base_denom": "uinit",
+            "chain_name": "initia"
+          },
+          "chain": {
+            "bridge_id": "12"
+          }
+        }
+      ],
+      "name": "Initia Native Token",
+      "symbol": "INIT",
+      "coingecko_id": "",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/mainnets/initia/images/INIT.png"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/mainnets/initia/images/INIT.png"
+      }
+    }
+  ]
+}

--- a/mainnets/civitia/chain.json
+++ b/mainnets/civitia/chain.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "../../chain.schema.json",
+  "chain_name": "civitia",
+  "pretty_name": "Civitia",
+  "chain_id": "civitia-1",
+  "bech32_prefix": "init",
+  "network_type": "mainnet",
+  "codebase": {
+    "git_repo": "https://github.com/initia-labs/minimove",
+    "recommended_version": "v1.0.2",
+    "binaries": {
+      "linux/amd64": "https://github.com/initia-labs/minimove/releases/download/v1.0.2/minimove_v1.0.2_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/initia-labs/minimove/releases/download/v1.0.2/minimove_v1.0.2_Linux_aarch64.tar.gz",
+      "darwin/amd64": "https://github.com/initia-labs/minimove/releases/download/v1.0.2/minimove_v1.0.2_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/initia-labs/minimove/releases/download/v1.0.2/minimove_v1.0.2_Darwin_aarch64.tar.gz"
+    },
+    "genesis": {
+      "genesis_url": "https://rpc-civitia-1.anvil.asia-southeast.initia.xyz/genesis"
+    }
+  },
+  "apis": {
+    "rpc": [
+      {
+        "address": "https://rpc-civitia-1.anvil.asia-southeast.initia.xyz"
+      }
+    ],
+    "rest": [
+      {
+        "address": "https://rest-civitia-1.anvil.asia-southeast.initia.xyz"
+      }
+    ],
+    "grpc": [
+      {
+        "address": "grpc-civitia-1.anvil.asia-southeast.initia.xyz:443"
+      }
+    ]
+  },
+  "key_algos": [
+    "ethsecp256k1"
+  ],
+  "slip44": 60,
+  "fees": {
+    "fee_tokens": [
+      {
+        "denom": "l2/2b2d36f666e98b9eecf70d6ec24b882b79f2c8e2af73f54f97b8b670dbb87605",
+        "fixed_min_gas_price": 0.015
+      }
+    ]
+  },
+  "images": [
+    {
+      "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/mainnets/civitia/images/civitia.png"
+    }
+  ],
+  "logo_URIs": {
+    "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/mainnets/civitia/images/civitia.png"
+  },
+  "metadata": {
+    "op_bridge_id": "12",
+    "op_denoms": [
+      "uinit"
+    ],
+    "executor_uri": "https://opinit-api-civitia-1.anvil.asia-southeast.initia.xyz",
+    "ibc_channels": [
+      {
+        "chain_id": "interwoven-1",
+        "port_id": "nft-transfer",
+        "channel_id": "channel-1",
+        "version": "ics721-1"
+      },
+      {
+        "chain_id": "interwoven-1",
+        "port_id": "transfer",
+        "channel_id": "channel-0",
+        "version": "ics20-1"
+      }
+    ],
+    "assetlist": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/mainnets/civitia/assetlist.json",
+    "minitia": {
+      "type": "minimove",
+      "version": "v1.0.2"
+    }
+  }
+}

--- a/mainnets/civitia/chain.json
+++ b/mainnets/civitia/chain.json
@@ -49,11 +49,11 @@
   },
   "images": [
     {
-      "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/mainnets/civitia/images/civitia.png"
+      "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/civitia.png"
     }
   ],
   "logo_URIs": {
-    "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/mainnets/civitia/images/civitia.png"
+    "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/civitia.png"
   },
   "metadata": {
     "op_bridge_id": "12",

--- a/mainnets/initia/chain.json
+++ b/mainnets/initia/chain.json
@@ -188,6 +188,18 @@
         "port_id": "transfer",
         "channel_id": "channel-25",
         "version": "ics20-1"
+      },
+      {
+        "chain_id": "civitia-1",
+        "port_id": "nft-transfer",
+        "channel_id": "channel-28",
+        "version": "ics721-1"
+      },
+      {
+        "chain_id": "civitia-1",
+        "port_id": "transfer",
+        "channel_id": "channel-27",
+        "version": "ics20-1"
       }
     ]
   }

--- a/mainnets/yominet/assetlist.json
+++ b/mainnets/yominet/assetlist.json
@@ -14,20 +14,10 @@
           "exponent": 18
         }
       ],
+      "type_asset": "erc20",
+      "address": "0x856aB2c9F35B9187aB3eB0Fcd11DCc6160427e96",
       "base": "evm/856aB2c9F35B9187aB3eB0Fcd11DCc6160427e96",
       "display": "INIT",
-      "traces": [
-        {
-          "type": "op",
-          "counterparty": {
-            "base_denom": "uinit",
-            "chain_name": "initia"
-          },
-          "chain": {
-            "bridge_id": "11"
-          }
-        }
-      ],
       "name": "Initia Native Token",
       "symbol": "INIT",
       "coingecko_id": "",

--- a/mainnets/yominet/assetlist.json
+++ b/mainnets/yominet/assetlist.json
@@ -6,15 +6,15 @@
       "description": "The native token of Initia",
       "denom_units": [
         {
-          "denom": "l2/8f73cfaf153520f511b4fc0bd71d60d64b4e19eff04a350e642718a3c1ab3b06",
+          "denom": "evm/856aB2c9F35B9187aB3eB0Fcd11DCc6160427e96",
           "exponent": 0
         },
         {
           "denom": "INIT",
-          "exponent": 6
+          "exponent": 18
         }
       ],
-      "base": "l2/8f73cfaf153520f511b4fc0bd71d60d64b4e19eff04a350e642718a3c1ab3b06",
+      "base": "evm/856aB2c9F35B9187aB3eB0Fcd11DCc6160427e96",
       "display": "INIT",
       "traces": [
         {
@@ -38,194 +38,6 @@
       ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
-      }
-    },
-    {
-      "description": "Circle’s USD Coin on Initia",
-      "denom_units": [
-        {
-          "denom": "l2/32c6f95dc503698022e06088840f5eba8f4a4eae57b86bd2640feb6a0f3b18f8",
-          "exponent": 0
-        },
-        {
-          "denom": "USDC",
-          "exponent": 6
-        }
-      ],
-      "base": "l2/32c6f95dc503698022e06088840f5eba8f4a4eae57b86bd2640feb6a0f3b18f8",
-      "display": "USDC",
-      "name": "USD Coin",
-      "symbol": "USDC",
-      "coingecko_id": "",
-      "traces": [
-        {
-          "type": "ibc",
-          "counterparty": {
-            "chain_name": "noble",
-            "base_denom": "uusdc",
-            "channel_id": "channel-129"
-          },
-          "chain": {
-            "channel_id": "channel-3",
-            "path": "transfer/channel-3/uusdc"
-          }
-        },
-        {
-          "type": "op",
-          "counterparty": {
-            "base_denom": "ibc/6490A7EAB61059BFC1CDDEB05917DD70BDF3A611654162A1A47DB930D40D8AF4",
-            "chain_name": "initia"
-          },
-          "chain": {
-            "bridge_id": "11"
-          }
-        }
-      ],
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/USDC.png"
-        }
-      ],
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/USDC.png"
-      }
-    },
-    {
-      "description": "Milkyway’s liquid staked TIA on Initia",
-      "denom_units": [
-        {
-          "denom": "l2/7d8374bd7b0289ee895a260fd45577ae23b7e6946cae8c0deb60d750f054e1ad",
-          "exponent": 0
-        },
-        {
-          "denom": "milkTIA",
-          "exponent": 6
-        }
-      ],
-      "base": "l2/7d8374bd7b0289ee895a260fd45577ae23b7e6946cae8c0deb60d750f054e1ad",
-      "display": "milkTIA",
-      "name": "milkTIA",
-      "symbol": "milkTIA",
-      "coingecko_id": "",
-      "traces": [
-        {
-          "type": "ibc",
-          "counterparty": {
-            "chain_name": "osmosis",
-            "base_denom": "factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA",
-            "channel_id": "channel-100108"
-          },
-          "chain": {
-            "channel_id": "channel-0",
-            "path": "transfer/channel-0/factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA"
-          }
-        },
-        {
-          "type": "op",
-          "counterparty": {
-            "base_denom": "ibc/16065EE5282C5217685C8F084FC44864C25C706AC37356B0D62811D50B96920F",
-            "chain_name": "initia"
-          },
-          "chain": {
-            "bridge_id": "11"
-          }
-        }
-      ],
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/milkTIA.png"
-        }
-      ],
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/milkTIA.png"
-      }
-    },
-    {
-      "description": "The native token of Celestia on Initia via IBC",
-      "denom_units": [
-        {
-          "denom": "l2/a39ea81b865d2392baf42825768cc63c973bb028e826370ede91aa560384d297",
-          "exponent": 0
-        },
-        {
-          "denom": "TIA",
-          "exponent": 6
-        }
-      ],
-      "base": "l2/a39ea81b865d2392baf42825768cc63c973bb028e826370ede91aa560384d297",
-      "display": "TIA",
-      "name": "Celestia",
-      "symbol": "TIA",
-      "coingecko_id": "",
-      "traces": [
-        {
-          "type": "ibc",
-          "counterparty": {
-            "chain_name": "celestia",
-            "base_denom": "utia",
-            "channel_id": "channel-78"
-          },
-          "chain": {
-            "channel_id": "channel-10",
-            "path": "transfer/channel-10/utia"
-          }
-        },
-        {
-          "type": "op",
-          "counterparty": {
-            "base_denom": "ibc/DA9AC2708B4DAA46D24E73241373CDCC850BC6446E8E0906A4062152B649DDD3",
-            "chain_name": "initia"
-          },
-          "chain": {
-            "bridge_id": "11"
-          }
-        }
-      ],
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/TIA.png"
-        }
-      ],
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/TIA.png"
-      }
-    },
-    {
-      "description": "ETH token",
-      "denom_units": [
-        {
-          "denom": "l2/2c1ab7b2d0d8bf67c45f1ea458dc2810a30d54ea02215bc1596d97b9e3127438",
-          "exponent": 0
-        },
-        {
-          "denom": "ETH",
-          "exponent": 6
-        }
-      ],
-      "base": "l2/2c1ab7b2d0d8bf67c45f1ea458dc2810a30d54ea02215bc1596d97b9e3127438",
-      "display": "ETH",
-      "name": "ETH Token",
-      "symbol": "ETH",
-      "coingecko_id": "",
-      "traces": [
-        {
-          "type": "op",
-          "counterparty": {
-            "base_denom": "move/c3b42c557c243205835971567f9516c78208f342023cf1c0c15ed8f3d3a6a271",
-            "chain_name": "initia"
-          },
-          "chain": {
-            "bridge_id": "11"
-          }
-        }
-      ],
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/ETH.png"
-        }
-      ],
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/ETH.png"
       }
     }
   ]


### PR DESCRIPTION
- civitia

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added comprehensive chain configuration and asset list files for the "civitia" mainnet, including metadata, endpoints, token details, and visual assets.
  - Extended interoperability by adding new IBC channels for fungible token and NFT transfers between "initia" and "civitia" chains.

- **Refactor**
  - Simplified the "yominet" asset list by retaining only the native ERC-20 token, updating its denomination format and metadata, and removing all other token entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->