### PR TITLE
add rave and usdc on zaarmainnet

### DIFF
--- a/mainnets/initia/chain.json
+++ b/mainnets/initia/chain.json
@@ -260,6 +260,18 @@
         "port_id": "transfer",
         "channel_id": "channel-58",
         "version": "ics20-1"
+      },
+      {
+        "chain_id": "rave-1",
+        "port_id": "nft-transfer",
+        "channel_id": "channel-39",
+        "version": "ics721-1"
+      },
+      {
+        "chain_id": "rave-1",
+        "port_id": "transfer",
+        "channel_id": "channel-38",
+        "version": "ics20-1"
       }
     ]
   }

--- a/mainnets/rave/assetlist.json
+++ b/mainnets/rave/assetlist.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "../../assetlist.schema.json",
+  "chain_name": "rave",
+  "assets": [
+    {
+      "description": "The native token of Initia",
+      "denom_units": [
+        {
+          "denom": "evm/4f7566f67941283a30cf65de7b9c6fdf2c04fca1",
+          "exponent": 0
+        },
+        {
+          "denom": "INIT",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "erc20",
+      "address": "0x4f7566f67941283a30cf65de7b9c6fdf2c04fca1",
+      "base": "evm/4f7566f67941283a30cf65de7b9c6fdf2c04fca1",
+      "display": "INIT",
+      "name": "Initia Native Token",
+      "symbol": "INIT",
+      "coingecko_id": "",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
+      }
+    }
+  ]
+}

--- a/mainnets/rave/chain.json
+++ b/mainnets/rave/chain.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "../../chain.schema.json",
+  "chain_name": "rave",
+  "pretty_name": "Rave",
+  "chain_id": "rave-1",
+  "evm_chain_id": 555110192329996,
+  "bech32_prefix": "init",
+  "network_type": "mainnet",
+  "codebase": {
+    "git_repo": "https://github.com/initia-labs/minievm",
+    "recommended_version": "v1.0.4",
+    "binaries": {
+      "linux/amd64": "https://github.com/initia-labs/minievm/releases/download/v1.0.4/minievm_v1.0.4_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/initia-labs/minievm/releases/download/v1.0.4/minievm_v1.0.4_Linux_aarch64.tar.gz",
+      "darwin/amd64": "https://github.com/initia-labs/minievm/releases/download/v1.0.4/minievm_v1.0.4_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/initia-labs/minievm/releases/download/v1.0.4/minievm_v1.0.4_Darwin_aarch64.tar.gz"
+    },
+    "genesis": {
+      "genesis_url": "https://rpc-rave-1.anvil.asia-southeast.initia.xyz/genesis"
+    }
+  },
+  "apis": {
+    "rpc": [
+      {
+        "address": "https://rpc-rave-1.anvil.asia-southeast.initia.xyz"
+      }
+    ],
+    "rest": [
+      {
+        "address": "https://rest-rave-1.anvil.asia-southeast.initia.xyz"
+      }
+    ],
+    "grpc": [
+      {
+        "address": "grpc-rave-1.anvil.asia-southeast.initia.xyz:443"
+      }
+    ],
+    "json-rpc": [
+      {
+        "address": "https://jsonrpc-rave-1.anvil.asia-southeast.initia.xyz"
+      }
+    ],
+    "json-rpc-websocket": [
+      {
+        "address": "wss://jsonrpc-ws-rave-1.anvil.asia-southeast.initia.xyz"
+      }
+    ]
+  },
+  "key_algos": [
+    "ethsecp256k1"
+  ],
+  "slip44": 60,
+  "fees": {
+    "fee_tokens": [
+      {
+        "denom": "evm/4f7566f67941283a30cf65de7b9c6fdf2c04fca1",
+        "fixed_min_gas_price": 15000000000
+      }
+    ]
+  },
+  "images": [
+    {
+      "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/mainnets/rave/images/rave.png"
+    }
+  ],
+  "logo_URIs": {
+    "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/mainnets/rave/images/rave.png"
+  },
+  "metadata": {
+    "op_bridge_id": "17",
+    "op_denoms": [
+      "uinit"
+    ],
+    "executor_uri": "https://opinit-api-rave-1.anvil.asia-southeast.initia.xyz",
+    "ibc_channels": [
+      {
+        "chain_id": "interwoven-1",
+        "port_id": "nft-transfer",
+        "channel_id": "channel-1",
+        "version": "ics721-1"
+      },
+      {
+        "chain_id": "interwoven-1",
+        "port_id": "transfer",
+        "channel_id": "channel-0",
+        "version": "ics20-1"
+      }
+    ],
+    "assetlist": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/mainnets/rave/assetlist.json",
+    "minitia": {
+      "type": "minievm",
+      "version": "v1.0.4"
+    }
+  }
+}

--- a/mainnets/rave/chain.json
+++ b/mainnets/rave/chain.json
@@ -60,11 +60,11 @@
   },
   "images": [
     {
-      "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/mainnets/rave/images/rave.png"
+      "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/rave.png"
     }
   ],
   "logo_URIs": {
-    "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/mainnets/rave/images/rave.png"
+    "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/rave.png"
   },
   "metadata": {
     "op_bridge_id": "17",

--- a/mainnets/zaarmainnet/assetlist.json
+++ b/mainnets/zaarmainnet/assetlist.json
@@ -29,6 +29,34 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
       }
+    },
+    {
+      "description": "Circle’s USD Coin on Initia",
+      "denom_units": [
+        {
+          "denom": "evm/bb4d87cb72e9a515d0846a8801f07d887eef1c13",
+          "exponent": 0
+        },
+        {
+          "denom": "USDC",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "erc20",
+      "address": "0xbb4d87cb72e9a515d0846a8801f07d887eef1c13",
+      "base": "evm/bb4d87cb72e9a515d0846a8801f07d887eef1c13",
+      "display": "USDC",
+      "name": "USD Coin",
+      "symbol": "USDC",
+      "coingecko_id": "",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/USDC.png"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/USDC.png"
+      }
     }
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added full support and configuration for the Rave mainnet, including network endpoints, fee structure, and visual assets.
  - Introduced an asset list for the Rave chain featuring the Initia Native Token (INIT).
  - Added USD Coin (USDC) as a new asset on the Zaar mainnet with complete metadata.
  - Enabled NFT and token transfers between Initia and the Rave chain via new IBC channels.

- **Chores**
  - Updated configuration and asset list files to reflect new chain and asset support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->