### PR TITLE
feat(initia): use normal secp256k1 key altos

### DIFF
--- a/mainnets/initia/chain.json
+++ b/mainnets/initia/chain.json
@@ -9,7 +9,7 @@
   "bech32_prefix": "init",
   "daemon_name": "initiad",
   "node_home": "$HOME/.initia",
-  "key_algos": ["ethsecp256k1"],
+  "key_algos": ["secp256k1"],
   "slip44": 60,
   "fees": {
     "fee_tokens": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the supported key algorithm for the Initia mainnet chain configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->