### PR TITLE
Update civitia vip description

### DIFF
--- a/profiles/civitia.json
+++ b/profiles/civitia.json
@@ -14,7 +14,7 @@
     "actions": [
       {
         "title": "Earn SILVER",
-        "description": "Earn SILVER by playing Civitia seasons with an active residence."
+        "description": "The VIP score in each epoch is equal to the SILVER accrued during the epoch, except referral earnings"
       }
     ]
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the description for the "Earn SILVER" action in the VIP section to clarify that VIP scores per epoch reflect SILVER earned during that epoch, excluding referral earnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->