### PR TITLE
update rave assetlist

### DIFF
--- a/mainnets/echelon/assetlist.json
+++ b/mainnets/echelon/assetlist.json
@@ -44,7 +44,7 @@
       "description": "MilkyWay's Liquid Staked TIA",
       "denom_units": [
         {
-          "denom": "ibc/9BC51D80E55DA9CDA11876EA5A56708C3C25BBF876BC26952F7A756E47FF3E3B",
+          "denom": "ibc/D1FAD67CE0EF5A303EDC29F3730BF904B77817F4B8A515ABC3AD0FA21B6AA180",
           "exponent": 0
         },
         {
@@ -52,7 +52,7 @@
           "exponent": 6
         }
       ],
-      "base": "ibc/9BC51D80E55DA9CDA11876EA5A56708C3C25BBF876BC26952F7A756E47FF3E3B",
+      "base": "ibc/D1FAD67CE0EF5A303EDC29F3730BF904B77817F4B8A515ABC3AD0FA21B6AA180",
       "display": "milkTIA",
       "name": "milkTIA",
       "symbol": "milkTIA",

--- a/mainnets/initia/assetlist.json
+++ b/mainnets/initia/assetlist.json
@@ -216,33 +216,6 @@
       }
     },
     {
-      "description": "Ether.Fi's Wrapped eETH LRT",
-      "denom_units": [
-        {
-          "denom": "move/bcf6c17467320f8aec451165823d73af3049f9c9dfbeaff98b92ec0165a58bf8",
-          "exponent": 0
-        },
-        {
-          "denom": "WEETH",
-          "exponent": 6
-        }
-      ],
-      "base": "move/bcf6c17467320f8aec451165823d73af3049f9c9dfbeaff98b92ec0165a58bf8",
-      "display": "WEETH",
-      "name": "Ether.Fi Wrapped eETH LRT",
-      "symbol": "WEETH",
-      "coingecko_id": "",
-      "traces": [],
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/weETH.png"
-        }
-      ],
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/weETH.png"
-      }
-    },
-    {
       "description": "The LST of INIT by Inertia",
       "denom_units": [
         {

--- a/mainnets/rave/assetlist.json
+++ b/mainnets/rave/assetlist.json
@@ -31,31 +31,115 @@
       }
     },
     {
-      "description": "Ether.Fi's Wrapped eETH LRT",
+      "description": "MilkyWay's Liquid Staked TIA",
       "denom_units": [
         {
-          "denom": "evm/9b51c105b768dF44d78bE80B53aD45579b7ee103",
+          "denom": "evm/f0c644D9636b83E7491404d8D826321e44E23d15",
           "exponent": 0
         },
         {
-          "denom": "WEETH",
+          "denom": "milkTIA",
           "exponent": 18
         }
       ],
       "type_asset": "erc20",
-      "address": "0x9b51c105b768dF44d78bE80B53aD45579b7ee103",
-      "base": "evm/9b51c105b768dF44d78bE80B53aD45579b7ee103",
-      "display": "WEETH",
-      "name": "Ether.Fi Wrapped eETH LRT",
-      "symbol": "WEETH",
+      "address": "0xf0c644D9636b83E7491404d8D826321e44E23d15",
+      "base": "evm/f0c644D9636b83E7491404d8D826321e44E23d15",
+      "display": "milkTIA",
+      "name": "milkTIA",
+      "symbol": "milkTIA",
       "coingecko_id": "",
       "images": [
         {
-          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/weETH.png"
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/milkTIA.png"
         }
       ],
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/weETH.png"
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/milkTIA.png"
+      }
+    },
+    {
+      "description": "USDC on Initia",
+      "denom_units": [
+        {
+          "denom": "evm/4E5f559ff873D84834e4338950d4Bb05121f8EFc",
+          "exponent": 0
+        },
+        {
+          "denom": "USDC",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "erc20",
+      "address": "0x4E5f559ff873D84834e4338950d4Bb05121f8EFc",
+      "base": "evm/4E5f559ff873D84834e4338950d4Bb05121f8EFc",
+      "display": "USDC",
+      "name": "USD Coin",
+      "symbol": "USDC",
+      "coingecko_id": "",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/USDC.png"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/USDC.png"
+      }
+    },
+    {
+      "description": "The native token of Celestia on Initia via IBC",
+      "denom_units": [
+        {
+          "denom": "evm/44CFAaB1cF49996540A6B6A87d1f0a604267E6b0",
+          "exponent": 0
+        },
+        {
+          "denom": "TIA",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "erc20",
+      "address": "0x44CFAaB1cF49996540A6B6A87d1f0a604267E6b0",
+      "base": "evm/44CFAaB1cF49996540A6B6A87d1f0a604267E6b0",
+      "display": "TIA",
+      "name": "Celestia Native Token",
+      "symbol": "TIA",
+      "coingecko_id": "",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/TIA.png"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/TIA.png"
+      }
+    },
+    {
+      "description": "ETH token via LayerZero",
+      "denom_units": [
+        {
+          "denom": "evm/E1Ff7038eAAAF027031688E1535a055B2Bac2546",
+          "exponent": 0
+        },
+        {
+          "denom": "ETH",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "erc20",
+      "address": "0xE1Ff7038eAAAF027031688E1535a055B2Bac2546",
+      "base": "evm/E1Ff7038eAAAF027031688E1535a055B2Bac2546",
+      "display": "ETH",
+      "name": "Ethereum Native Token",
+      "symbol": "ETH",
+      "coingecko_id": "",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/ETH.png"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/ETH.png"
       }
     }
   ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new asset entries for "USDC on Initia", "Celestia (TIA) via IBC", and "ETH via LayerZero" to the Rave asset list.

- **Updates**
  - Updated the asset entry for "MilkyWay's Liquid Staked TIA" on Echelon and Rave, including denomination changes and metadata updates.

- **Removals**
  - Removed "Ether.Fi's Wrapped eETH LRT" (WEETH) from the Initia asset list and replaced it with "MilkyWay's Liquid Staked TIA" on Rave.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->