### PR TITLE
Fix weETH base denom

### DIFF
--- a/mainnets/initia/assetlist.json
+++ b/mainnets/initia/assetlist.json
@@ -305,7 +305,7 @@
           "exponent": 6
         }
       ],
-      "base": "WEETH",
+      "base": "move/0eba36d73e4f8d0c10b36323fbd28ab8b3783b003ba7b86c0f3ead32a1caf7f7",
       "display": "WEETH",
       "name": "Ether.Fi Wrapped eETH LRT",
       "symbol": "WEETH",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the base denomination for "Ether.Fi Wrapped eETH LRT" on Initia to accurately reflect the full Move module address, ensuring consistency with denomination identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->