### PR TITLE
feat: add virgaze-1 nft transfer channel

### DIFF
--- a/testnets/initia/chain.json
+++ b/testnets/initia/chain.json
@@ -341,6 +341,12 @@
         "port_id": "nft-transfer",
         "channel_id": "channel-2454",
         "version": "ics721-1"
+      },
+      {
+        "chain_id": "virgaze-1",
+        "port_id": "nft-transfer",
+        "channel_id": "channel-1586",
+        "version": "ics721-1"
       }
     ],
     "assetlist": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/initia/assetlist.json"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for an additional NFT transfer channel on the Initia testnet, enabling NFT transfers with the Virgaze-1 network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->