### PR TITLE
revert profile.webapp

### DIFF
--- a/profile.schema.json
+++ b/profile.schema.json
@@ -83,11 +83,6 @@
           "format": "uri",
           "pattern": "^https://."
         },
-        "webapp": {
-          "type": "string",
-          "format": "uri",
-          "pattern": "^https://."
-        },
         "twitter": {
           "type": "string",
           "format": "uri",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the "webapp" field from the social section of Chain Profile objects. Only "website" and "twitter" fields are now supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->