### PR TITLE
Add BFB Token on initia L1

### DIFF
--- a/mainnets/initia/assetlist.json
+++ b/mainnets/initia/assetlist.json
@@ -452,8 +452,8 @@
             "channel_id": "channel-0"
           },
           "chain": {
-            "channel_id": "channel-25",
-            "path": "transfer/channel-25/evm/6f7Ff6916Ea4ab0159a469388C6bD6C17b40041a"
+            "channel_id": "channel-60",
+            "path": "transfer/channel-60/evm/6f7Ff6916Ea4ab0159a469388C6bD6C17b40041a"
           }
         }
       ],

--- a/mainnets/initia/assetlist.json
+++ b/mainnets/initia/assetlist.json
@@ -424,6 +424,47 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/USDe.png"
       }
+    },
+    
+    {
+      "description": "In-game currency of Battle for Blockchain",
+      "denom_units": [
+        {
+          "denom": "ibc/A5376B6C69C98C5FA0C3834A5F74966DF98AEEA758BA35104A5BAF095FB49789",
+          "exponent": 0
+        },
+        {
+          "denom": "BFB",
+          "exponent": 18
+        }
+      ],
+      "base": "ibc/A5376B6C69C98C5FA0C3834A5F74966DF98AEEA758BA35104A5BAF095FB49789",
+      "display": "BFB",
+      "name": "BFB",
+      "symbol": "BFB",
+      "coingecko_id": "",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "bfb",
+            "base_denom": "evm/6f7Ff6916Ea4ab0159a469388C6bD6C17b40041a",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-25",
+            "path": "transfer/channel-25/evm/6f7Ff6916Ea4ab0159a469388C6bD6C17b40041a"
+          }
+        }
+      ],
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/BFB.png"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/BFB.png"
+      }
     }
   ]
 }

--- a/mainnets/initia/assetlist.json
+++ b/mainnets/initia/assetlist.json
@@ -448,12 +448,12 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "bfb",
-            "base_denom": "evm/6f7Ff6916Ea4ab0159a469388C6bD6C17b40041a",
+            "base_denom": "evm/6922eF1A57aA7F4475dc2E03604923faC4001661",
             "channel_id": "channel-0"
           },
           "chain": {
             "channel_id": "channel-60",
-            "path": "transfer/channel-60/evm/6f7Ff6916Ea4ab0159a469388C6bD6C17b40041a"
+            "path": "transfer/channel-60/evm/6922eF1A57aA7F4475dc2E03604923faC4001661"
           }
         }
       ],

--- a/mainnets/initia/assetlist.json
+++ b/mainnets/initia/assetlist.json
@@ -435,7 +435,7 @@
         },
         {
           "denom": "BFB",
-          "exponent": 18
+          "exponent": 6
         }
       ],
       "base": "ibc/A5376B6C69C98C5FA0C3834A5F74966DF98AEEA758BA35104A5BAF095FB49789",

--- a/mainnets/initia/chain.json
+++ b/mainnets/initia/chain.json
@@ -275,6 +275,18 @@
         "port_id": "transfer",
         "channel_id": "channel-38",
         "version": "ics20-1"
+      },
+      {
+        "chain_id": "bfb-1",
+        "port_id": "nft-transfer",
+        "channel_id": "channel-61",
+        "version": "ics721-1"
+      },
+      {
+        "chain_id": "bfb-1",
+        "port_id": "transfer",
+        "channel_id": "channel-60",
+        "version": "ics20-1"
       }
     ]
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the "BFB" in-game currency asset for Battle for Blockchain on the Initia chain.
  - Included new IBC channels for token and NFT transfers with the BFB chain in the Initia chain configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->