### PR TITLE
Revert "Hide bfb"

### DIFF
--- a/mainnets/bfb/assetlist.json
+++ b/mainnets/bfb/assetlist.json
@@ -29,6 +29,34 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
       }
+    },
+    {
+      "description": "In-game currency of Battle for Blockchain",
+      "denom_units": [
+        {
+          "denom": "evm/6f7Ff6916Ea4ab0159a469388C6bD6C17b40041a",
+          "exponent": 0
+        },
+        {
+          "denom": "BFB",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "erc20",
+      "address": "0x6f7Ff6916Ea4ab0159a469388C6bD6C17b40041a",
+      "base": "evm/6f7Ff6916Ea4ab0159a469388C6bD6C17b40041a",
+      "display": "BFB",
+      "name": "BFB",
+      "symbol": "BFB",
+      "coingecko_id": "",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/BFB.png"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/BFB.png"
+      }
     }
   ]
 }


### PR DESCRIPTION
Reverts initia-labs/initia-registry#572

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the "BFB" token, the in-game currency of Battle for Blockchain, including its display information and logo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->