### PR TITLE
fix testbfb-3 case

### DIFF
--- a/testnets/testbfb/assetlist.json
+++ b/testnets/testbfb/assetlist.json
@@ -6,7 +6,7 @@
       "description": "The native token of Initia",
       "denom_units": [
         {
-          "denom": "evm/6ed1637781269560b204c27cd42d95e057c4be44",
+          "denom": "evm/6ed1637781269560b204c27Cd42d95e057C4BE44",
           "exponent": 0
         },
         {
@@ -16,7 +16,7 @@
       ],
       "type_asset": "erc20",
       "address": "0x6ed1637781269560b204c27cd42d95e057c4be44",
-      "base": "evm/6ed1637781269560b204c27cd42d95e057c4be44",
+      "base": "evm/6ed1637781269560b204c27Cd42d95e057C4BE44",
       "display": "INIT",
       "name": "Initia Native Token",
       "symbol": "INIT",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the casing of the hexadecimal string in the "denom" and "base" fields for the Initia native token asset in the asset list. No other changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->