### PR TITLE
chore: only use lb endpoint in registry

### DIFF
--- a/testnets/embr_old/chain.json
+++ b/testnets/embr_old/chain.json
@@ -41,55 +41,25 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://rpc-0-embr-1.anvil.asia-southeast.initia.xyz"
-      },
-      {
-        "address": "https://rpc-1-embr-1.anvil.asia-southeast.initia.xyz"
-      },
-      {
         "address": "https://rpc-embr-1.anvil.asia-southeast.initia.xyz"
       }
     ],
     "rest": [
-      {
-        "address": "https://rest-0-embr-1.anvil.asia-southeast.initia.xyz"
-      },
-      {
-        "address": "https://rest-1-embr-1.anvil.asia-southeast.initia.xyz"
-      },
       {
         "address": "https://rest-embr-1.anvil.asia-southeast.initia.xyz"
       }
     ],
     "grpc": [
       {
-        "address": "grpc-0-embr-1.anvil.asia-southeast.initia.xyz:443"
-      },
-      {
-        "address": "grpc-1-embr-1.anvil.asia-southeast.initia.xyz:443"
-      },
-      {
         "address": "grpc-embr-1.anvil.asia-southeast.initia.xyz:443"
       }
     ],
     "json-rpc": [
       {
-        "address": "https://jsonrpc-0-embr-1.anvil.asia-southeast.initia.xyz"
-      },
-      {
-        "address": "https://jsonrpc-1-embr-1.anvil.asia-southeast.initia.xyz"
-      },
-      {
         "address": "https://jsonrpc-embr-1.anvil.asia-southeast.initia.xyz"
       }
     ],
     "json-rpc-websocket": [
-      {
-        "address": "wss://jsonrpc-ws-0-embr-1.anvil.asia-southeast.initia.xyz"
-      },
-      {
-        "address": "wss://jsonrpc-ws-1-embr-1.anvil.asia-southeast.initia.xyz"
-      },
       {
         "address": "wss://jsonrpc-ws-embr-1.anvil.asia-southeast.initia.xyz"
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Simplified API endpoint listings in the configuration by removing redundant entries, leaving only one address per API type. This streamlines and clarifies the available endpoints for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->