### PR TITLE
fix: fix op_denoms

### DIFF
--- a/mainnets/inertia/chain.json
+++ b/mainnets/inertia/chain.json
@@ -63,7 +63,11 @@
   "metadata": {
     "op_bridge_id": "32",
     "op_denoms": [
-      "uinit"
+      "uinit",
+      "ibc/DA9AC2708B4DAA46D24E73241373CDCC850BC6446E8E0906A4062152B649DDD3",
+      "ibc/6490A7EAB61059BFC1CDDEB05917DD70BDF3A611654162A1A47DB930D40D8AF4",
+      "move/d08cf4d36d8a70cc6efe8791dc5b3d4f928df4fe41468bc138439d55ed132c3e",
+      "move/b4fd0119fa43bb5a208256e92977d6552fef31191fe24299fe45f6e64dd5c6f3"
     ],
     "executor_uri": "https://op-executor.inrt.fi",
     "ibc_channels": [

--- a/mainnets/intergaze/chain.json
+++ b/mainnets/intergaze/chain.json
@@ -61,7 +61,10 @@
   },
   "metadata": {
     "op_bridge_id": "31",
-    "op_denoms": ["uinit"],
+    "op_denoms": [
+      "uinit",
+      "ibc/6490A7EAB61059BFC1CDDEB05917DD70BDF3A611654162A1A47DB930D40D8AF4"
+    ],
     "executor_uri": "https://executor.intergaze-apis.com",
     "ibc_channels": [
       {

--- a/mainnets/moo/chain.json
+++ b/mainnets/moo/chain.json
@@ -63,7 +63,7 @@
   },
   "metadata": {
     "op_bridge_id": "13",
-    "op_denoms": ["uinit"],
+    "op_denoms": [],
     "executor_uri": "https://opinit-api-moo-1.anvil.asia-southeast.initia.xyz",
     "ibc_channels": [
       {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new token denominations to the supported list for Inertia and Intergaze networks.

- **Chores**
  - Updated token denomination metadata for Inertia, Intergaze, and Moo networks. Moo network now shows no supported denominations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->