### PR TITLE
change zaar and rena chain name

### DIFF
--- a/mainnets/rena/assetlist.json
+++ b/mainnets/rena/assetlist.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../assetlist.schema.json",
-  "chain_name": "renanuwa",
+  "chain_name": "rena",
   "assets": [
     {
       "description": "The native token of Initia",

--- a/mainnets/rena/chain.json
+++ b/mainnets/rena/chain.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../chain.schema.json",
-  "chain_name": "renanuwa",
+  "chain_name": "rena",
   "pretty_name": "Rena",
   "chain_id": "rena-nuwa-1",
   "website": "https://renalabs.xyz",
@@ -85,7 +85,7 @@
         "version": "ics20-1"
       }
     ],
-    "assetlist": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/mainnets/renanuwa/assetlist.json",
+    "assetlist": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/mainnets/rena/assetlist.json",
     "minitia": {
       "type": "minimove",
       "version": "v1.0.2"

--- a/mainnets/zaar/assetlist.json
+++ b/mainnets/zaar/assetlist.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../assetlist.schema.json",
-  "chain_name": "zaarmainnet",
+  "chain_name": "zaar",
   "assets": [
     {
       "description": "The native token of Initia",

--- a/mainnets/zaar/chain.json
+++ b/mainnets/zaar/chain.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../chain.schema.json",
-  "chain_name": "zaarmainnet",
+  "chain_name": "zaar",
   "pretty_name": "Zaar",
   "chain_id": "zaar-mainnet-1",
   "website": "https://flip.zaar.gg/",
@@ -92,7 +92,7 @@
         "version": "ics20-1"
       }
     ],
-    "assetlist": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/mainnets/zaarmainnet/assetlist.json",
+    "assetlist": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/mainnets/zaar/assetlist.json",
     "minitia": {
       "type": "minievm",
       "version": "v1.0.3"

--- a/profiles/rena.json
+++ b/profiles/rena.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../profile.schema.json",
-  "name": "renanuwa",
+  "name": "rena",
   "pretty_name": "Rena",
   "category": "AI",
   "tags": ["TEE", "Infra"],

--- a/profiles/zaar.json
+++ b/profiles/zaar.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../profile.schema.json",
-  "name": "zaarmainnet",
+  "name": "zaar",
   "pretty_name": "Zaar",
   "category": "Gaming",
   "l2": true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated chain and profile names for the Rena and Zaar networks to reflect their current naming conventions.
  - Adjusted related asset list URLs to match the updated chain names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->