### PR TITLE
Add new Civitia Testnet (landlord-3)

### DIFF
--- a/testnets/civitia/assetlist.json
+++ b/testnets/civitia/assetlist.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "../../assetlist.schema.json",
+    "chain_name": "civitia",
+    "assets": [
+      {
+        "description": "The native token of Initia",
+        "denom_units": [
+          {
+            "denom": "l2/a8dd0d513498ff9fb555c6592ec60d78c8bd7b1ab0db7d4c7b4fc322e30ee904",
+            "exponent": 0
+          },
+          {
+            "denom": "INIT",
+            "exponent": 6
+          }
+        ],
+        "base": "l2/a8dd0d513498ff9fb555c6592ec60d78c8bd7b1ab0db7d4c7b4fc322e30ee904",
+        "display": "INIT",
+        "traces": [
+          {
+            "type": "op",
+            "counterparty": {
+              "base_denom": "uinit",
+              "chain_name": "initia"
+            },
+            "chain": {
+              "bridge_id": "1229"
+            }
+          }
+        ],
+        "name": "Initia Native Token",
+        "symbol": "INIT",
+        "coingecko_id": "",
+        "images": [
+          {
+            "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
+          }
+        ],
+        "logo_URIs": {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
+        }
+      }
+    ]
+  }

--- a/testnets/civitia/chain.json
+++ b/testnets/civitia/chain.json
@@ -1,0 +1,84 @@
+{
+    "$schema": "../../chain.schema.json",
+    "chain_name": "civitia",
+    "pretty_name": "Civitia",
+    "chain_id": "landlord-3",
+    "bech32_prefix": "init",
+    "network_type": "testnet",
+    "codebase": {
+      "git_repo": "https://github.com/initia-labs/minimove",
+      "recommended_version": "v1.0.2",
+      "binaries": {
+        "linux/amd64": "https://github.com/initia-labs/minimove/releases/download/v1.0.2/minimove_v1.0.2_Linux_x86_64.tar.gz",
+        "linux/arm64": "https://github.com/initia-labs/minimove/releases/download/v1.0.2/minimove_v1.0.2_Linux_aarch64.tar.gz",
+        "darwin/amd64": "https://github.com/initia-labs/minimove/releases/download/v1.0.2/minimove_v1.0.2_Darwin_x86_64.tar.gz",
+        "darwin/arm64": "https://github.com/initia-labs/minimove/releases/download/v1.0.2/minimove_v1.0.2_Darwin_aarch64.tar.gz"
+      },
+      "genesis": {
+        "genesis_url": "https://rpc-landlord-3.anvil.asia-southeast.initia.xyz/genesis"
+      }
+    },
+    "apis": {
+      "rpc": [
+        {
+          "address": "https://rpc-landlord-3.anvil.asia-southeast.initia.xyz"
+        }
+      ],
+      "rest": [
+        {
+          "address": "https://rest-landlord-3.anvil.asia-southeast.initia.xyz"
+        }
+      ],
+      "grpc": [
+        {
+          "address": "grpc-landlord-3.anvil.asia-southeast.initia.xyz:443"
+        }
+      ]
+    },
+    "key_algos": [
+      "secp256k1"
+    ],
+    "slip44": 118,
+    "fees": {
+      "fee_tokens": [
+        {
+          "denom": "l2/a8dd0d513498ff9fb555c6592ec60d78c8bd7b1ab0db7d4c7b4fc322e30ee904",
+          "fixed_min_gas_price": 0.015
+        }
+      ]
+    },
+    "images": [
+      {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/civitia.png"
+      }
+    ],
+    "logo_URIs": {
+      "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/civitia.png"
+    },
+    "metadata": {
+      "op_bridge_id": "1229",
+      "op_denoms": [
+        "uinit"
+      ],
+      "executor_uri": "https://opinit-api-landlord-3.anvil.asia-southeast.initia.xyz",
+      "ibc_channels": [
+        {
+          "chain_id": "initiation-2",
+          "port_id": "nft-transfer",
+          "channel_id": "channel-1",
+          "version": "ics721-1"
+        },
+        {
+          "chain_id": "initiation-2",
+          "port_id": "transfer",
+          "channel_id": "channel-0",
+          "version": "ics20-1"
+        }
+      ],
+      "assetlist": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/civitia/assetlist.json",
+      "minitia": {
+        "type": "minimove",
+        "version": "v1.0.2"
+      }
+    }
+  }

--- a/testnets/initia/chain.json
+++ b/testnets/initia/chain.json
@@ -257,6 +257,18 @@
         "port_id": "nft-transfer",
         "channel_id": "channel-1586",
         "version": "ics721-1"
+      },
+      {
+        "chain_id": "landlord-3",
+        "port_id": "transfer",
+        "channel_id": "channel-2605",
+        "version": "ics20-1"
+      },
+      {
+        "chain_id": "landlord-3",
+        "port_id": "nft-transfer",
+        "channel_id": "channel-2606",
+        "version": "ics721-1"
       }
     ],
     "assetlist": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/testnets/initia/assetlist.json"


### PR DESCRIPTION
`landlord-2` was deprecated

adding `landlord-3` registry content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for the "civitia" testnet chain, including its network configuration and metadata.
	- Introduced an asset list for the "civitia" testnet with details for its native token.
	- Expanded IBC channel support on the "initia" testnet with new transfer and NFT-transfer channels linked to "civitia".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->