### PR TITLE
feat: add missing l1 channels

### DIFF
--- a/mainnets/initia/chain.json
+++ b/mainnets/initia/chain.json
@@ -287,6 +287,30 @@
         "port_id": "transfer",
         "channel_id": "channel-60",
         "version": "ics20-1"
+      },
+      {
+        "chain_id": "embrmainnet-1",
+        "port_id": "nft-transfer",
+        "channel_id": "channel-63",
+        "version": "ics721-1"
+      },
+      {
+        "chain_id": "embrmainnet-1",
+        "port_id": "transfer",
+        "channel_id": "channel-62",
+        "version": "ics20-1"
+      },
+      {
+        "chain_id": "rena-nuwa-1",
+        "port_id": "nft-transfer",
+        "channel_id": "channel-65",
+        "version": "ics721-1"
+      },
+      {
+        "chain_id": "rena-nuwa-1",
+        "port_id": "transfer",
+        "channel_id": "channel-64",
+        "version": "ics20-1"
       }
     ]
   }


### PR DESCRIPTION
add embrmainnet and rena-nuwa ibc channels on layer 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for IBC channels with the Embrmainnet-1 and Rena-nuwa-1 chains, enabling both NFT and fungible token transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->