### PR TITLE
Add coingecko ids

### DIFF
--- a/mainnets/bfb/assetlist.json
+++ b/mainnets/bfb/assetlist.json
@@ -20,7 +20,7 @@
       "display": "INIT",
       "name": "Initia Native Token",
       "symbol": "INIT",
-      "coingecko_id": "",
+      "coingecko_id": "initia",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"

--- a/mainnets/civitia/assetlist.json
+++ b/mainnets/civitia/assetlist.json
@@ -30,7 +30,7 @@
       ],
       "name": "Initia Native Token",
       "symbol": "INIT",
-      "coingecko_id": "",
+      "coingecko_id": "initia",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"

--- a/mainnets/echelon/assetlist.json
+++ b/mainnets/echelon/assetlist.json
@@ -30,7 +30,7 @@
       ],
       "name": "Initia Native Token",
       "symbol": "INIT",
-      "coingecko_id": "",
+      "coingecko_id": "initia",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
@@ -96,7 +96,7 @@
       "display": "USDC",
       "name": "USD Coin",
       "symbol": "USDC",
-      "coingecko_id": "",
+      "coingecko_id": "usd-coin",
       "traces": [
         {
           "type": "ibc",
@@ -136,7 +136,7 @@
       "display": "TIA",
       "name": "Celestia Native Token",
       "symbol": "TIA",
-      "coingecko_id": "",
+      "coingecko_id": "celestia",
       "traces": [
         {
           "type": "ibc",
@@ -176,7 +176,7 @@
       "display": "ETH",
       "name": "Ethereum Native Token",
       "symbol": "ETH",
-      "coingecko_id": "",
+      "coingecko_id": "ethereum",
       "traces": [
         {
           "type": "ibc",
@@ -216,7 +216,7 @@
       "display": "WEETH",
       "name": "Ether.Fi Wrapped eETH LRT",
       "symbol": "WEETH",
-      "coingecko_id": "",
+      "coingecko_id": "wrapped-eeth",
       "traces": [
         {
           "type": "ibc",

--- a/mainnets/embr/assetlist.json
+++ b/mainnets/embr/assetlist.json
@@ -20,7 +20,7 @@
       "display": "INIT",
       "name": "Initia Native Token",
       "symbol": "INIT",
-      "coingecko_id": "",
+      "coingecko_id": "initia",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"

--- a/mainnets/inertia/assetlist.json
+++ b/mainnets/inertia/assetlist.json
@@ -18,7 +18,7 @@
       "display": "INIT",
       "name": "Initia Native Token",
       "symbol": "INIT",
-      "coingecko_id": "",
+      "coingecko_id": "initia",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
@@ -56,7 +56,7 @@
       "display": "TIA",
       "name": "Celestia Native Token",
       "symbol": "TIA",
-      "coingecko_id": "",
+      "coingecko_id": "celestia",
       "traces": [
         {
           "type": "ibc",
@@ -106,7 +106,7 @@
       "display": "USDC",
       "name": "USD Coin",
       "symbol": "USDC",
-      "coingecko_id": "",
+      "coingecko_id": "usd-coin",
       "traces": [
         {
           "type": "ibc",

--- a/mainnets/ingnetwork/assetlist.json
+++ b/mainnets/ingnetwork/assetlist.json
@@ -20,7 +20,7 @@
       "display": "INIT",
       "name": "Initia Native Token",
       "symbol": "INIT",
-      "coingecko_id": "",
+      "coingecko_id": "initia",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"

--- a/mainnets/intergaze/assetlist.json
+++ b/mainnets/intergaze/assetlist.json
@@ -30,7 +30,7 @@
             ],
             "name": "Initia Native Token",
             "symbol": "INIT",
-            "coingecko_id": "",
+            "coingecko_id": "initia",
             "images": [
                 {
                     "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
@@ -56,7 +56,7 @@
             "display": "USDC",
             "name": "USD Coin",
             "symbol": "USDC",
-            "coingecko_id": "",
+            "coingecko_id": "usd-coin",
             "traces": [
                 {
                     "type": "ibc",

--- a/mainnets/moo/assetlist.json
+++ b/mainnets/moo/assetlist.json
@@ -18,7 +18,7 @@
       "display": "INIT",
       "name": "Initia Native Token",
       "symbol": "INIT",
-      "coingecko_id": "",
+      "coingecko_id": "initia",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"

--- a/mainnets/rave/assetlist.json
+++ b/mainnets/rave/assetlist.json
@@ -20,7 +20,7 @@
       "display": "INIT",
       "name": "Initia Native Token",
       "symbol": "INIT",
-      "coingecko_id": "",
+      "coingecko_id": "initia",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
@@ -48,7 +48,7 @@
       "display": "USDC",
       "name": "USD Coin",
       "symbol": "USDC",
-      "coingecko_id": "",
+      "coingecko_id": "usd-coin",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/USDC.png"

--- a/mainnets/rena/assetlist.json
+++ b/mainnets/rena/assetlist.json
@@ -30,7 +30,7 @@
       ],
       "name": "Initia Native Token",
       "symbol": "INIT",
-      "coingecko_id": "",
+      "coingecko_id": "initia",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"

--- a/mainnets/yominet/assetlist.json
+++ b/mainnets/yominet/assetlist.json
@@ -20,7 +20,7 @@
       "display": "INIT",
       "name": "Initia Native Token",
       "symbol": "INIT",
-      "coingecko_id": "",
+      "coingecko_id": "initia",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
@@ -76,7 +76,7 @@
       "display": "ETH",
       "name": "Ethereum Native Token",
       "symbol": "ETH",
-      "coingecko_id": "",
+      "coingecko_id": "ethereum",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/ETH.png"
@@ -104,7 +104,7 @@
       "display": "TIA",
       "name": "Celestia TIA",
       "symbol": "TIA",
-      "coingecko_id": "",
+      "coingecko_id": "celestia",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/TIA.png"

--- a/mainnets/zaar/assetlist.json
+++ b/mainnets/zaar/assetlist.json
@@ -20,7 +20,7 @@
       "display": "INIT",
       "name": "Initia Native Token",
       "symbol": "INIT",
-      "coingecko_id": "",
+      "coingecko_id": "initia",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
@@ -48,7 +48,7 @@
       "display": "USDC",
       "name": "USD Coin",
       "symbol": "USDC",
-      "coingecko_id": "",
+      "coingecko_id": "usd-coin",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/USDC.png"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CoinGecko IDs for various assets across multiple networks, including Initia Native Token, USD Coin, Celestia, Ethereum, and Ether.Fi Wrapped eETH LRT, to improve asset metadata consistency and accuracy. No other asset properties were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->