### PR TITLE
Add MILK asset

### DIFF
--- a/mainnets/initia/assetlist.json
+++ b/mainnets/initia/assetlist.json
@@ -1082,6 +1082,46 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/sxINIT.png"
       }
+    },
+    {
+      "description": "The native token of MilkyWay on Initia via IBC",
+      "denom_units": [
+        {
+          "denom": "ibc/991E01AB189A00585E4BBBE04D7B7C8654D16BF612C7B795F175679164114642",
+          "exponent": 0
+        },
+        {
+          "denom": "MILK",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/991E01AB189A00585E4BBBE04D7B7C8654D16BF612C7B795F175679164114642",
+      "display": "MILK",
+      "name": "MilkyWay Native Token",
+      "symbol": "MILK",
+      "coingecko_id": "milkyway",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "milkyway",
+            "base_denom": "umilk",
+            "channel_id": "channel-5"
+          },
+          "chain": {
+            "channel_id": "channel-80",
+            "path": "transfer/channel-80/umilk"
+          }
+        }
+      ],
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/MILK.png"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/MILK.png"
+      }
     }
   ]
 }

--- a/mainnets/initia/chain.json
+++ b/mainnets/initia/chain.json
@@ -311,6 +311,24 @@
         "port_id": "transfer",
         "channel_id": "channel-64",
         "version": "ics20-1"
+      },
+      {
+        "chain_id": "milkyway",
+        "port_id": "transfer",
+        "channel_id": "channel-80",
+        "version": "ics20-1"
+      },
+      {
+        "chain_id": "moo-1",
+        "port_id": "transfer",
+        "channel_id": "channel-29",
+        "version": "ics20-1"
+      },
+      {
+        "chain_id": "moo-1",
+        "port_id": "nft-transfer",
+        "channel_id": "channel-30",
+        "version": "ics721-1"
       }
     ]
   }

--- a/mainnets/moo/assetlist.json
+++ b/mainnets/moo/assetlist.json
@@ -53,6 +53,46 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/milkINIT.png"
       }
+    },
+    {
+      "description": "The native token of MilkyWay on Initia via IBC",
+      "denom_units": [
+        {
+          "denom": "ibc/31DE4445E2BD6142E020EBDE6B1BD617C71B89F767E89D286919AC12AA3EF559",
+          "exponent": 0
+        },
+        {
+          "denom": "MILK",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/31DE4445E2BD6142E020EBDE6B1BD617C71B89F767E89D286919AC12AA3EF559",
+      "display": "MILK",
+      "name": "MilkyWay Native Token",
+      "symbol": "MILK",
+      "coingecko_id": "milkyway",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "initia",
+            "base_denom": "ibc/991E01AB189A00585E4BBBE04D7B7C8654D16BF612C7B795F175679164114642",
+            "channel_id": "channel-29"
+          },
+          "chain": {
+            "channel_id": "channel-0",
+            "path": "transfer/channel-0/transfer/channel-80/umilk"
+          }
+        }
+      ],
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/MILK.png"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/MILK.png"
+      }
     }
   ]
 }


### PR DESCRIPTION
This PR adds MILK to both Initia and MilkyWay rollup's asset list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for the MilkyWay Native Token (MILK) on both the Initia and Moo networks, including token details, IBC transfer information, and token logo display.
	- Introduced new IBC channels for enhanced inter-blockchain communication with MilkyWay and Moo networks, supporting both token and NFT transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->