### PR TITLE
feat(interwoven-1): add upgrade info

### DIFF
--- a/mainnets/initia/chain.json
+++ b/mainnets/initia/chain.json
@@ -35,13 +35,13 @@
   },
   "codebase": {
     "git_repo": "https://github.com/initia-labs/initia",
-    "recommended_version": "v1.0.0",
-    "compatible_versions": ["v1.0.0"],
+    "recommended_version": "v1.1.2",
+    "compatible_versions": ["v1.1.2"],
     "binaries": {
-      "linux/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0/initia_v1.0.0_Linux_x86_64.tar.gz",
-      "linux/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0/initia_v1.0.0_Linux_aarch64.tar.gz",
-      "darwin/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0/initia_v1.0.0_Darwin_x86_64.tar.gz",
-      "darwin/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0/initia_v1.0.0_Darwin_aarch64.tar.gz"
+      "linux/amd64": "https://github.com/initia-labs/initia/releases/download/v1.1.2/initia_v1.1.2_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/initia-labs/initia/releases/download/v1.1.2/initia_v1.1.2_Linux_aarch64.tar.gz",
+      "darwin/amd64": "https://github.com/initia-labs/initia/releases/download/v1.1.2/initia_v1.1.2_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/initia-labs/initia/releases/download/v1.1.2/initia_v1.1.2_Darwin_aarch64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://storage.googleapis.com/init-common-genesis/interwoven-1/genesis.json"
@@ -81,6 +81,18 @@
           "linux/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0/initia_v1.0.0_Linux_aarch64.tar.gz",
           "darwin/amd64": "https://github.com/initia-labs/initia/releases/download/v1.0.0/initia_v1.0.0_Darwin_x86_64.tar.gz",
           "darwin/arm64": "https://github.com/initia-labs/initia/releases/download/v1.0.0/initia_v1.0.0_Darwin_aarch64.tar.gz"
+        }
+      },
+      {
+        "name": "1.1.2",
+        "recommended_version": "v1.1.2",
+        "compatible_versions": ["v1.1.2"],
+        "height": 3400000,
+        "binaries": {
+          "linux/amd64": "https://github.com/initia-labs/initia/releases/download/v1.1.2/initia_v1.1.2_Linux_x86_64.tar.gz",
+          "linux/arm64": "https://github.com/initia-labs/initia/releases/download/v1.1.2/initia_v1.1.2_Linux_aarch64.tar.gz",
+          "darwin/amd64": "https://github.com/initia-labs/initia/releases/download/v1.1.2/initia_v1.1.2_Darwin_x86_64.tar.gz",
+          "darwin/arm64": "https://github.com/initia-labs/initia/releases/download/v1.1.2/initia_v1.1.2_Darwin_aarch64.tar.gz"
         }
       }
     ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the recommended and compatible version for Initia mainnet to v1.1.2.
  - Updated binary download links for all supported platforms to the new version.
  - Added a new version entry for v1.1.2, effective from block height 3,400,000.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->