### PR TITLE
Remove minievm-2 fee token 

### DIFF
--- a/testnets/minievm/chain.json
+++ b/testnets/minievm/chain.json
@@ -16,10 +16,10 @@
     "fee_tokens": [
       {
         "denom": "GAS",
-        "fixed_min_gas_price": 15000000000.0,
-        "low_gas_price": 15000000000.0,
-        "average_gas_price": 15000000000.0,
-        "high_gas_price": 40000000000.0
+        "fixed_min_gas_price": 0,
+        "low_gas_price": 0,
+        "average_gas_price": 0,
+        "high_gas_price": 0
       }
     ]
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated gas price parameters for the "GAS" fee token in the testnet configuration, setting all gas price values to zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->