### PR TITLE
feat: add chain_id on trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ main().catch((error) => {
 | `assets[].name`          | `string`                 | Yes           | The human-readable name of the asset (e.g., “Initia Native Token”).                                                                                                                                                                 |
 | `assets[].symbol`        | `string`                 | Yes           | The short symbol for the asset (e.g., `INIT`, `USDC`, “ONYX”).                                                                                                                                                                      |
 | `assets[].coingecko_id`  | `string`                 | Optional      | Reference ID for CoinGecko, if the asset is or will be listed.                                                                                                                                                                      |
-| `assets[].traces`        | `object[]`               | Optional      | IBC or OP bridging info. Contains nested fields like `type` (`ibc`, `op`), a `counterparty` object (chain_name, base_denom, channel_id), and a `chain` object (channel_id, path, bridge_id).                                       |
+| `assets[].traces`        | `object[]`               | Optional      | IBC or OP bridging info. Contains nested fields like `type` (`ibc`, `op`), a `counterparty` object (chain_name, chain_id, base_denom, channel_id), and a `chain` object (channel_id, path, bridge_id).                                       |
 | `assets[].images`        | `object[]`               | Optional      | Array of image objects with links to PNG for the asset’s logo.                                                                                                                                                                 |
 | `assets[].images[].png`  | `string (URL)`           | Optional      | PNG logo URL.                                                                                                                                                                                                                       |
 | `assets[].logo_URIs`     | `object`                 | Optional      | Simplified or alternative object containing the `png` fields for direct image references.      
@@ -433,6 +433,7 @@ An example assetlist json contains the following structure:
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "interwoven-1",
             "base_denom": "uusdc",
             "channel_id": "channel-1629"
           },
@@ -470,7 +471,8 @@ An example assetlist json contains the following structure:
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "80"

--- a/assetlist.schema.json
+++ b/assetlist.schema.json
@@ -220,11 +220,15 @@
         },
         "counterparty": {
           "type": "object",
-          "required": ["chain_name", "base_denom", "channel_id"],
+          "required": ["chain_name", "chain_id", "base_denom", "channel_id"],
           "properties": {
             "chain_name": {
               "type": "string",
               "description": "The name of the counterparty chain. (must match exactly the chain name used in the Chain Registry)"
+            },
+            "chain_id": {
+              "type": "string",
+              "description": "The chain id of the counterparty chain."
             },
             "base_denom": {
               "type": "string",
@@ -267,11 +271,21 @@
         },
         "counterparty": {
           "type": "object",
-          "required": ["chain_name", "base_denom", "port", "channel_id"],
+          "required": [
+            "chain_name",
+            "chain_id",
+            "base_denom",
+            "port",
+            "channel_id"
+          ],
           "properties": {
             "chain_name": {
               "type": "string",
               "description": "The name of the counterparty chain. (must match exactly the chain name used in the Chain Registry)"
+            },
+            "chain_id": {
+              "type": "string",
+              "description": "The chain id of the counterparty chain."
             },
             "base_denom": {
               "type": "string",
@@ -322,11 +336,15 @@
         },
         "counterparty": {
           "type": "object",
-          "required": ["chain_name", "base_denom"],
+          "required": ["chain_name", "chain_id", "base_denom"],
           "properties": {
             "chain_name": {
               "type": "string",
               "description": "The name of the counterparty chain. (must match exactly the chain name used in the Chain Registry)"
+            },
+            "chain_id": {
+              "type": "string",
+              "description": "The chain id of the counterparty chain."
             },
             "base_denom": {
               "type": "string",
@@ -366,11 +384,15 @@
         },
         "counterparty": {
           "type": "object",
-          "required": ["chain_name", "base_denom"],
+          "required": ["chain_name", "chain_id", "base_denom"],
           "properties": {
             "chain_name": {
               "type": "string",
               "description": "The chain or platform from which the asset originates. E.g., 'cosmoshub', 'ethereum', 'forex', or 'nasdaq'"
+            },
+            "chain_id": {
+              "type": "string",
+              "description": "The chain id of the counterparty chain."
             },
             "base_denom": {
               "type": "string"

--- a/mainnets/bfb/assetlist.json
+++ b/mainnets/bfb/assetlist.json
@@ -26,7 +26,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "28"
@@ -36,6 +37,7 @@
           "type": "wrapped",
           "counterparty": {
             "chain_name": "bfb",
+            "chain_id": "bfb-1",
             "base_denom": "l2/5d3ed5b0870d4c8d8715a1bf92d8e99b8e49fbc1c0a29a0572485c7ff783b23b"
           },
           "chain": {

--- a/mainnets/civitia/assetlist.json
+++ b/mainnets/civitia/assetlist.json
@@ -21,7 +21,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "12"

--- a/mainnets/echelon/assetlist.json
+++ b/mainnets/echelon/assetlist.json
@@ -21,7 +21,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "16"
@@ -62,6 +63,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "moo",
+            "chain_id": "moo-1",
             "base_denom": "factory/init17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgsj6uxxj/umilkINIT",
             "channel_id": "channel-0"
           },
@@ -74,6 +76,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "interwoven-1",
             "base_denom": "ibc/39B55F22F15FB09189045A993817CDF0D388D3FF8773B2E22B6DE7B222636EEA",
             "channel_id": "channel-35"
           },
@@ -114,6 +117,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "noble",
+            "chain_id": "noble-1",
             "base_denom": "uusdc",
             "channel_id": "channel-129"
           },
@@ -126,6 +130,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "interwoven-1",
             "base_denom": "ibc/6490A7EAB61059BFC1CDDEB05917DD70BDF3A611654162A1A47DB930D40D8AF4",
             "channel_id": "channel-35"
           },
@@ -166,6 +171,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "celestia",
+            "chain_id": "celestia",
             "base_denom": "utia",
             "channel_id": "channel-78"
           },
@@ -178,6 +184,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "interwoven-1",
             "base_denom": "ibc/DA9AC2708B4DAA46D24E73241373CDCC850BC6446E8E0906A4062152B649DDD3",
             "channel_id": "channel-35"
           },
@@ -218,6 +225,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "interwoven-1",
             "base_denom": "move/edfcddacac79ab86737a1e9e65805066d8be286a37cb94f4884b892b0e39f954",
             "channel_id": "channel-35"
           },
@@ -258,6 +266,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "interwoven-1",
             "base_denom": "move/0eba36d73e4f8d0c10b36323fbd28ab8b3783b003ba7b86c0f3ead32a1caf7f7",
             "channel_id": "channel-35"
           },
@@ -298,6 +307,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "osmosis",
+            "chain_id": "osmosis-1",
             "base_denom": "factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA",
             "channel_id": "channel-102129"
           },
@@ -310,6 +320,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "interwoven-1",
             "base_denom": "ibc/297A4DE88667929480EBE6659B264C5683838CF313C61FE889F6B8D8DC6E071D",
             "channel_id": "channel-35"
           },
@@ -350,6 +361,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "neutron",
+            "chain_id": "neutron-1",
             "base_denom": "factory/neutron10546f0nskmykr27s85l953gztyevxluqdd3ycl0guf648p68r2fsukxxnr/udinit",
             "channel_id": "channel-6885"
           },
@@ -362,6 +374,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "interwoven-1",
             "base_denom": "ibc/6190D58F741F1313A7B8F07E34E5603B03C1CC4490F54474986BC97A55EADE92",
             "channel_id": "channel-35"
           },
@@ -402,6 +415,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "interwoven-1",
             "base_denom": "move/08e72bfc8d55d9705e4cea82ddb68ad84e5b7a16ec4ef4bb0d3c95bf729569fb",
             "channel_id": "channel-35"
           },

--- a/mainnets/embr/assetlist.json
+++ b/mainnets/embr/assetlist.json
@@ -26,7 +26,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "29"
@@ -36,6 +37,7 @@
           "type": "wrapped",
           "counterparty": {
             "chain_name": "embr",
+            "chain_id": "embrmainnet-1",
             "base_denom": "l2/5c7570d305b2d43f6cf33b41043d9429daa5d2a1038095a894febdc308966ff3"
           },
           "chain": {

--- a/mainnets/inertia/assetlist.json
+++ b/mainnets/inertia/assetlist.json
@@ -32,7 +32,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "32"
@@ -62,6 +63,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "celestia",
+            "chain_id": "celestia",
             "base_denom": "utia",
             "channel_id": "channel-78"
           },
@@ -74,7 +76,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "ibc/DA9AC2708B4DAA46D24E73241373CDCC850BC6446E8E0906A4062152B649DDD3",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "32"
@@ -112,6 +115,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "noble",
+            "chain_id": "noble-1",
             "base_denom": "uusdc",
             "channel_id": "channel-129"
           },
@@ -124,7 +128,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "ibc/6490A7EAB61059BFC1CDDEB05917DD70BDF3A611654162A1A47DB930D40D8AF4",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "32"
@@ -159,7 +164,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "move/d08cf4d36d8a70cc6efe8791dc5b3d4f928df4fe41468bc138439d55ed132c3e",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "32"
@@ -197,7 +203,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "move/b4fd0119fa43bb5a208256e92977d6552fef31191fe24299fe45f6e64dd5c6f3",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "32"

--- a/mainnets/ingnetwork/assetlist.json
+++ b/mainnets/ingnetwork/assetlist.json
@@ -26,7 +26,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "27"
@@ -36,6 +37,7 @@
           "type": "wrapped",
           "counterparty": {
             "chain_name": "ingnetwork",
+            "chain_id": "ingnetwork-1",
             "base_denom": "l2/4daa1ce1a1956bf454f4a22bd6ecc7932737c88e1c3868dcd208684e0d432009"
           },
           "chain": {

--- a/mainnets/initia/assetlist.json
+++ b/mainnets/initia/assetlist.json
@@ -50,6 +50,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "noble",
+            "chain_id": "noble-1",
             "base_denom": "uusdc",
             "channel_id": "channel-129"
           },
@@ -90,6 +91,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "osmosis",
+            "chain_id": "osmosis-1",
             "base_denom": "factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA",
             "channel_id": "channel-102129"
           },
@@ -130,6 +132,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "moo",
+            "chain_id": "moo-1",
             "base_denom": "factory/init17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgsj6uxxj/umilkINIT",
             "channel_id": "channel-0"
           },
@@ -170,6 +173,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "celestia",
+            "chain_id": "celestia",
             "base_denom": "utia",
             "channel_id": "channel-78"
           },
@@ -341,6 +345,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "neutron",
+            "chain_id": "neutron-1",
             "base_denom": "factory/neutron10546f0nskmykr27s85l953gztyevxluqdd3ycl0guf648p68r2fsukxxnr/udinit",
             "channel_id": "channel-6885"
           },
@@ -407,6 +412,7 @@
           "type": "wrapped",
           "counterparty": {
             "chain_name": "bfb",
+            "chain_id": "bfb-1",
             "base_denom": "evm/6f7Ff6916Ea4ab0159a469388C6bD6C17b40041a"
           },
           "chain": {
@@ -418,6 +424,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "bfb",
+            "chain_id": "bfb-1",
             "base_denom": "evm/6922eF1A57aA7F4475dc2E03604923faC4001661",
             "channel_id": "channel-0"
           },
@@ -458,6 +465,7 @@
           "type": "wrapped",
           "counterparty": {
             "chain_name": "yominet",
+            "chain_id": "yominet-1",
             "base_denom": "evm/4BaDFb501Ab304fF11217C44702bb9E9732E7CF4"
           },
           "chain": {
@@ -469,6 +477,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "yominet",
+            "chain_id": "yominet-1",
             "base_denom": "evm/44CFAaB1cF49996540A6B6A87d1f0a604267E6b0",
             "channel_id": "channel-0"
           },
@@ -535,7 +544,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "28"
@@ -545,6 +555,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "bfb",
+            "chain_id": "bfb-1",
             "base_denom": "l2/5d3ed5b0870d4c8d8715a1bf92d8e99b8e49fbc1c0a29a0572485c7ff783b23b",
             "channel_id": "channel-0"
           },
@@ -584,7 +595,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "12"
@@ -594,6 +606,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "civitia",
+            "chain_id": "civitia-1",
             "base_denom": "l2/2b2d36f666e98b9eecf70d6ec24b882b79f2c8e2af73f54f97b8b670dbb87605",
             "channel_id": "channel-0"
           },
@@ -633,7 +646,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "16"
@@ -643,6 +657,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "echelon",
+            "chain_id": "echelon-1",
             "base_denom": "l2/23c8396041db74441f4268d0c7e0533177dc3e028a47a8e584318f2d0c46fbe9",
             "channel_id": "channel-0"
           },
@@ -682,7 +697,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "29"
@@ -692,6 +708,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "embr",
+            "chain_id": "embrmainnet-1",
             "base_denom": "l2/5c7570d305b2d43f6cf33b41043d9429daa5d2a1038095a894febdc308966ff3",
             "channel_id": "channel-0"
           },
@@ -731,7 +748,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "27"
@@ -741,6 +759,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "ingnetwork",
+            "chain_id": "ingnetwork-1",
             "base_denom": "l2/4daa1ce1a1956bf454f4a22bd6ecc7932737c88e1c3868dcd208684e0d432009",
             "channel_id": "channel-0"
           },
@@ -780,7 +799,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "32"
@@ -790,6 +810,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "inertia",
+            "chain_id": "inertia-2",
             "base_denom": "l2/c88b68df2060ba982a80d3001afcb2d354031f6901df2391acb4f0e2f545c770",
             "channel_id": "channel-0"
           },
@@ -829,7 +850,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "31"
@@ -839,6 +861,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "intergaze",
+            "chain_id": "intergaze-1",
             "base_denom": "l2/fb936ffef4eb4019d82941992cc09ae2788ce7197fcb08cb00c4fe6f5e79184e",
             "channel_id": "channel-0"
           },
@@ -878,7 +901,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "17"
@@ -888,6 +912,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "rave",
+            "chain_id": "rave-1",
             "base_denom": "l2/ffea49d63cbadcfd749b4f635eca198b2f3b44cb1f6b580f5d201d58f3bf7aea",
             "channel_id": "channel-0"
           },
@@ -927,7 +952,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "30"
@@ -937,6 +963,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "rena",
+            "chain_id": "rena-nuwa-1",
             "base_denom": "l2/9d3d65bf3329e45ad659f9cbee7d6dc7b6246b001e32131a9b465215eab90562",
             "channel_id": "channel-0"
           },
@@ -976,7 +1003,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "11"
@@ -986,6 +1014,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "yominet",
+            "chain_id": "yominet-1",
             "base_denom": "l2/8f73cfaf153520f511b4fc0bd71d60d64b4e19eff04a350e642718a3c1ab3b06",
             "channel_id": "channel-0"
           },
@@ -1025,7 +1054,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "15"
@@ -1035,6 +1065,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "zaar",
+            "chain_id": "zaar-mainnet-1",
             "base_denom": "l2/a36904f28371e1718a83a0e6df4bb3db33decaacfca67aa702b3a66f2c89d61b",
             "channel_id": "channel-0"
           },
@@ -1127,6 +1158,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "milkyway",
+            "chain_id": "milkyway",
             "base_denom": "umilk",
             "channel_id": "channel-5"
           },

--- a/mainnets/intergaze/assetlist.json
+++ b/mainnets/intergaze/assetlist.json
@@ -1,94 +1,97 @@
 {
-    "$schema": "../../assetlist.schema.json",
-    "chain_name": "intergaze",
-    "assets": [
+  "$schema": "../../assetlist.schema.json",
+  "chain_name": "intergaze",
+  "assets": [
+    {
+      "description": "The native token of Initia",
+      "denom_units": [
         {
-            "description": "The native token of Initia",
-            "denom_units": [
-                {
-                    "denom": "l2/fb936ffef4eb4019d82941992cc09ae2788ce7197fcb08cb00c4fe6f5e79184e",
-                    "exponent": 0
-                },
-                {
-                    "denom": "INIT",
-                    "exponent": 6
-                }
-            ],
-            "base": "l2/fb936ffef4eb4019d82941992cc09ae2788ce7197fcb08cb00c4fe6f5e79184e",
-            "display": "INIT",
-            "traces": [
-                {
-                    "type": "op",
-                    "counterparty": {
-                        "base_denom": "uinit",
-                        "chain_name": "initia"
-                    },
-                    "chain": {
-                        "bridge_id": "31"
-                    }
-                }
-            ],
-            "name": "Initia Native Token",
-            "symbol": "INIT",
-            "coingecko_id": "initia",
-            "images": [
-                {
-                    "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
-                }
-            ],
-            "logo_URIs": {
-                "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
-            }
+          "denom": "l2/fb936ffef4eb4019d82941992cc09ae2788ce7197fcb08cb00c4fe6f5e79184e",
+          "exponent": 0
         },
         {
-            "description": "USDC on Initia",
-            "denom_units": [
-                {
-                    "denom": "l2/db147f1ded7ffcc336f5f8d1eff83c4feb95fcfff5c84f1b9c135444b816e48e",
-                    "exponent": 0
-                },
-                {
-                    "denom": "USDC",
-                    "exponent": 6
-                }
-            ],
-            "base": "l2/db147f1ded7ffcc336f5f8d1eff83c4feb95fcfff5c84f1b9c135444b816e48e",
-            "display": "USDC",
-            "name": "USD Coin",
-            "symbol": "USDC",
-            "coingecko_id": "usd-coin",
-            "traces": [
-                {
-                    "type": "ibc",
-                    "counterparty": {
-                        "chain_name": "noble",
-                        "base_denom": "uusdc",
-                        "channel_id": "channel-129"
-                    },
-                    "chain": {
-                        "channel_id": "channel-3",
-                        "path": "transfer/channel-3/uusdc"
-                    }
-                },
-                {
-                    "type": "op",
-                    "counterparty": {
-                        "base_denom": "ibc/6490A7EAB61059BFC1CDDEB05917DD70BDF3A611654162A1A47DB930D40D8AF4",
-                        "chain_name": "initia"
-                    },
-                    "chain": {
-                        "bridge_id": "31"
-                    }
-                }
-            ],
-            "images": [
-                {
-                    "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/USDC.png"
-                }
-            ],
-            "logo_URIs": {
-                "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/USDC.png"
-            }
+          "denom": "INIT",
+          "exponent": 6
         }
-    ]
+      ],
+      "base": "l2/fb936ffef4eb4019d82941992cc09ae2788ce7197fcb08cb00c4fe6f5e79184e",
+      "display": "INIT",
+      "traces": [
+        {
+          "type": "op",
+          "counterparty": {
+            "base_denom": "uinit",
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
+          },
+          "chain": {
+            "bridge_id": "31"
+          }
+        }
+      ],
+      "name": "Initia Native Token",
+      "symbol": "INIT",
+      "coingecko_id": "initia",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
+      }
+    },
+    {
+      "description": "USDC on Initia",
+      "denom_units": [
+        {
+          "denom": "l2/db147f1ded7ffcc336f5f8d1eff83c4feb95fcfff5c84f1b9c135444b816e48e",
+          "exponent": 0
+        },
+        {
+          "denom": "USDC",
+          "exponent": 6
+        }
+      ],
+      "base": "l2/db147f1ded7ffcc336f5f8d1eff83c4feb95fcfff5c84f1b9c135444b816e48e",
+      "display": "USDC",
+      "name": "USD Coin",
+      "symbol": "USDC",
+      "coingecko_id": "usd-coin",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "noble",
+            "chain_id": "noble-1",
+            "base_denom": "uusdc",
+            "channel_id": "channel-129"
+          },
+          "chain": {
+            "channel_id": "channel-3",
+            "path": "transfer/channel-3/uusdc"
+          }
+        },
+        {
+          "type": "op",
+          "counterparty": {
+            "base_denom": "ibc/6490A7EAB61059BFC1CDDEB05917DD70BDF3A611654162A1A47DB930D40D8AF4",
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
+          },
+          "chain": {
+            "bridge_id": "31"
+          }
+        }
+      ],
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/USDC.png"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/USDC.png"
+      }
+    }
+  ]
 }

--- a/mainnets/moo/assetlist.json
+++ b/mainnets/moo/assetlist.json
@@ -24,6 +24,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "interwoven-1",
             "base_denom": "uinit",
             "channel_id": "channel-29"
           },
@@ -90,6 +91,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "milkyway",
+            "chain_id": "milkyway",
             "base_denom": "umilk",
             "channel_id": "channel-5"
           },
@@ -102,6 +104,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "interwoven-1",
             "base_denom": "ibc/991E01AB189A00585E4BBBE04D7B7C8654D16BF612C7B795F175679164114642",
             "channel_id": "channel-29"
           },

--- a/mainnets/rave/assetlist.json
+++ b/mainnets/rave/assetlist.json
@@ -26,7 +26,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "17"
@@ -36,6 +37,7 @@
           "type": "wrapped",
           "counterparty": {
             "chain_name": "rave",
+            "chain_id": "rave-1",
             "base_denom": "l2/ffea49d63cbadcfd749b4f635eca198b2f3b44cb1f6b580f5d201d58f3bf7aea"
           },
           "chain": {
@@ -77,6 +79,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "noble",
+            "chain_id": "noble-1",
             "base_denom": "uusdc",
             "channel_id": "channel-129"
           },
@@ -89,6 +92,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "interwoven-1",
             "base_denom": "ibc/6490A7EAB61059BFC1CDDEB05917DD70BDF3A611654162A1A47DB930D40D8AF4",
             "channel_id": "channel-38"
           },
@@ -101,6 +105,7 @@
           "type": "wrapped",
           "counterparty": {
             "chain_name": "rave",
+            "chain_id": "rave-1",
             "base_denom": "ibc/AA4E7DF065DC4D4B29B8662A919295F525B19251FB2618C41C0DED3BD1128FEE"
           },
           "chain": {
@@ -142,6 +147,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "moo",
+            "chain_id": "moo-1",
             "base_denom": "factory/init17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgsj6uxxj/umilkINIT",
             "channel_id": "channel-0"
           },
@@ -154,6 +160,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "interwoven-1",
             "base_denom": "ibc/39B55F22F15FB09189045A993817CDF0D388D3FF8773B2E22B6DE7B222636EEA",
             "channel_id": "channel-38"
           },
@@ -166,6 +173,7 @@
           "type": "wrapped",
           "counterparty": {
             "chain_name": "rave",
+            "chain_id": "rave-1",
             "base_denom": "ibc/D1FAD67CE0EF5A303EDC29F3730BF904B77817F4B8A515ABC3AD0FA21B6AA180"
           },
           "chain": {
@@ -207,6 +215,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "osmosis",
+            "chain_id": "osmosis-1",
             "base_denom": "factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA",
             "channel_id": "channel-102129"
           },
@@ -219,6 +228,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "interwoven-1",
             "base_denom": "ibc/297A4DE88667929480EBE6659B264C5683838CF313C61FE889F6B8D8DC6E071D",
             "channel_id": "channel-38"
           },
@@ -231,6 +241,7 @@
           "type": "wrapped",
           "counterparty": {
             "chain_name": "rave",
+            "chain_id": "rave-1",
             "base_denom": "ibc/405E48C8163CB9AB41A00CAEA19BB8D33D5C5818D3F3CCF3B1967C3A06D17206"
           },
           "chain": {
@@ -271,7 +282,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "move/d08cf4d36d8a70cc6efe8791dc5b3d4f928df4fe41468bc138439d55ed132c3e",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "17"
@@ -281,6 +293,7 @@
           "type": "wrapped",
           "counterparty": {
             "chain_name": "rave",
+            "chain_id": "rave-1",
             "base_denom": "l2/48809a59e7b6ace3bf181720a1426d143995441a3178dc1f1b9ec5e176bd422c"
           },
           "chain": {
@@ -321,6 +334,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "neutron",
+            "chain_id": "neutron-1",
             "base_denom": "factory/neutron10546f0nskmykr27s85l953gztyevxluqdd3ycl0guf648p68r2fsukxxnr/udinit",
             "channel_id": "channel-6885"
           },
@@ -333,6 +347,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "interwoven-1",
             "base_denom": "ibc/6190D58F741F1313A7B8F07E34E5603B03C1CC4490F54474986BC97A55EADE92",
             "channel_id": "channel-38"
           },
@@ -345,6 +360,7 @@
           "type": "wrapped",
           "counterparty": {
             "chain_name": "rave",
+            "chain_id": "rave-1",
             "base_denom": "ibc/2BFE577D4A154A360D7BEC8D5FECC433ACAE6EF44A460F2D36A61410D9ADE6ED"
           },
           "chain": {

--- a/mainnets/rena/assetlist.json
+++ b/mainnets/rena/assetlist.json
@@ -21,7 +21,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "30"

--- a/mainnets/yominet/assetlist.json
+++ b/mainnets/yominet/assetlist.json
@@ -26,7 +26,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "11"
@@ -36,6 +37,7 @@
           "type": "wrapped",
           "counterparty": {
             "chain_name": "yominet",
+            "chain_id": "yominet-1",
             "base_denom": "l2/8f73cfaf153520f511b4fc0bd71d60d64b4e19eff04a350e642718a3c1ab3b06"
           },
           "chain": {
@@ -133,6 +135,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "celestia",
+            "chain_id": "celestia",
             "base_denom": "utia",
             "channel_id": "channel-78"
           },
@@ -145,6 +148,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "interwoven-1",
             "base_denom": "ibc/DA9AC2708B4DAA46D24E73241373CDCC850BC6446E8E0906A4062152B649DDD3",
             "channel_id": "channel-25"
           },
@@ -157,6 +161,7 @@
           "type": "wrapped",
           "counterparty": {
             "chain_name": "yominet",
+            "chain_id": "yominet-1",
             "base_denom": "ibc/05060A29687D6CA94E2CCD17A9C57AA0F2086DEC0964D677509DC2EBFE324D9E"
           },
           "chain": {

--- a/mainnets/zaar/assetlist.json
+++ b/mainnets/zaar/assetlist.json
@@ -26,7 +26,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "interwoven-1"
           },
           "chain": {
             "bridge_id": "15"
@@ -36,6 +37,7 @@
           "type": "wrapped",
           "counterparty": {
             "chain_name": "zaar",
+            "chain_id": "zaar-mainnet-1",
             "base_denom": "l2/a36904f28371e1718a83a0e6df4bb3db33decaacfca67aa702b3a66f2c89d61b"
           },
           "chain": {
@@ -77,6 +79,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "noble",
+            "chain_id": "noble-1",
             "base_denom": "uusdc",
             "channel_id": "channel-129"
           },
@@ -89,6 +92,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "interwoven-1",
             "base_denom": "ibc/6490A7EAB61059BFC1CDDEB05917DD70BDF3A611654162A1A47DB930D40D8AF4",
             "channel_id": "channel-33"
           },
@@ -101,6 +105,7 @@
           "type": "wrapped",
           "counterparty": {
             "chain_name": "zaar",
+            "chain_id": "zaar-mainnet-1",
             "base_denom": "ibc/AA4E7DF065DC4D4B29B8662A919295F525B19251FB2618C41C0DED3BD1128FEE"
           },
           "chain": {

--- a/testnets/civitia/assetlist.json
+++ b/testnets/civitia/assetlist.json
@@ -1,44 +1,45 @@
 {
-    "$schema": "../../assetlist.schema.json",
-    "chain_name": "civitia",
-    "assets": [
-      {
-        "description": "The native token of Initia",
-        "denom_units": [
-          {
-            "denom": "l2/a8dd0d513498ff9fb555c6592ec60d78c8bd7b1ab0db7d4c7b4fc322e30ee904",
-            "exponent": 0
+  "$schema": "../../assetlist.schema.json",
+  "chain_name": "civitia",
+  "assets": [
+    {
+      "description": "The native token of Initia",
+      "denom_units": [
+        {
+          "denom": "l2/a8dd0d513498ff9fb555c6592ec60d78c8bd7b1ab0db7d4c7b4fc322e30ee904",
+          "exponent": 0
+        },
+        {
+          "denom": "INIT",
+          "exponent": 6
+        }
+      ],
+      "base": "l2/a8dd0d513498ff9fb555c6592ec60d78c8bd7b1ab0db7d4c7b4fc322e30ee904",
+      "display": "INIT",
+      "traces": [
+        {
+          "type": "op",
+          "counterparty": {
+            "base_denom": "uinit",
+            "chain_name": "initia",
+            "chain_id": "initiation-2"
           },
-          {
-            "denom": "INIT",
-            "exponent": 6
+          "chain": {
+            "bridge_id": "1229"
           }
-        ],
-        "base": "l2/a8dd0d513498ff9fb555c6592ec60d78c8bd7b1ab0db7d4c7b4fc322e30ee904",
-        "display": "INIT",
-        "traces": [
-          {
-            "type": "op",
-            "counterparty": {
-              "base_denom": "uinit",
-              "chain_name": "initia"
-            },
-            "chain": {
-              "bridge_id": "1229"
-            }
-          }
-        ],
-        "name": "Initia Native Token",
-        "symbol": "INIT",
-        "coingecko_id": "initia",
-        "images": [
-          {
-            "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
-          }
-        ],
-        "logo_URIs": {
+        }
+      ],
+      "name": "Initia Native Token",
+      "symbol": "INIT",
+      "coingecko_id": "initia",
+      "images": [
+        {
           "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
         }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
       }
-    ]
-  }
+    }
+  ]
+}

--- a/testnets/embr/assetlist.json
+++ b/testnets/embr/assetlist.json
@@ -21,7 +21,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "initiation-2"
           },
           "chain": {
             "bridge_id": "1175"

--- a/testnets/embr_old/assetlist.json
+++ b/testnets/embr_old/assetlist.json
@@ -21,7 +21,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "initiation-2"
           },
           "chain": {
             "bridge_id": "823"
@@ -37,9 +38,9 @@
         }
       ],
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png" 
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/INIT.png"
       }
-    }, 
+    },
     {
       "description": "mock embrINIT",
       "denom_units": [

--- a/testnets/inertia/assetlist.json
+++ b/testnets/inertia/assetlist.json
@@ -21,7 +21,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "initiation-2"
           },
           "chain": {
             "bridge_id": "1171"
@@ -59,7 +60,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uusdc",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "initiation-2"
           },
           "chain": {
             "bridge_id": "1171"
@@ -97,7 +99,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "utia",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "initiation-2"
           },
           "chain": {
             "bridge_id": "1171"
@@ -135,7 +138,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "ueth",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "initiation-2"
           },
           "chain": {
             "bridge_id": "1171"
@@ -173,7 +177,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "move/2742a2f1ae087b1ade570bd02a78a81d2e629e764f5179f95367b7a3086aed36",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "initiation-2"
           },
           "chain": {
             "bridge_id": "1171"
@@ -211,7 +216,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "move/4a39f845c36fa8f9f4a200579a8d92aab2fbdb345dab7a110cf14d7d00760748",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "initiation-2"
           },
           "chain": {
             "bridge_id": "1171"

--- a/testnets/initia/assetlist.json
+++ b/testnets/initia/assetlist.json
@@ -336,6 +336,7 @@
           "type": "wrapped",
           "counterparty": {
             "chain_name": "minievm",
+            "chain_id": "minievm-2",
             "base_denom": "GAS"
           },
           "chain": {
@@ -347,6 +348,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "minievm",
+            "chain_id": "minievm-2",
             "base_denom": "evm/D0763d5Bb4751F84e2FeB12Aaf3D42867e66350d",
             "channel_id": "channel-0"
           },
@@ -387,6 +389,7 @@
           "type": "wrapped",
           "counterparty": {
             "chain_name": "zaar",
+            "chain_id": "zaar-testnet-5",
             "base_denom": "evm/6ed1637781269560b204c27Cd42d95e057C4BE44"
           },
           "chain": {
@@ -398,6 +401,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "zaar",
+            "chain_id": "zaar-testnet-5",
             "base_denom": "evm/4f7566f67941283a30cf65de7b9c6fdf2c04FCA1",
             "channel_id": "channel-0"
           },
@@ -542,6 +546,7 @@
           "type": "wrapped",
           "counterparty": {
             "chain_name": "minievm",
+            "chain_id": "minievm-1",
             "base_denom": "evm/09d1a05C3770653c1eF6e1230F6022714d4b41e8"
           },
           "chain": {
@@ -553,6 +558,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "culinaris",
+            "chain_id": "testbfb-3",
             "base_denom": "evm/9989cFca23e97B2AEd8EA21d9CF244A03Cc89f02",
             "channel_id": "channel-2"
           },

--- a/testnets/intergaze/assetlist.json
+++ b/testnets/intergaze/assetlist.json
@@ -47,6 +47,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "initiation-2",
             "base_denom": "uinit",
             "channel_id": "channel-1585"
           },

--- a/testnets/milkyway/assetlist.json
+++ b/testnets/milkyway/assetlist.json
@@ -69,7 +69,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "initiation-2"
           },
           "chain": {
             "bridge_id": "822"
@@ -110,6 +111,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "initiation-2",
             "base_denom": "uusdc",
             "channel_id": "channel-0"
           },

--- a/testnets/minievm/assetlist.json
+++ b/testnets/minievm/assetlist.json
@@ -23,7 +23,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "initiation-2"
           },
           "chain": {
             "bridge_id": "1"
@@ -90,6 +91,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "initiation-2",
             "base_denom": "ueth",
             "channel_id": "channel-0"
           },
@@ -132,6 +134,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "initiation-2",
             "base_denom": "uusdc",
             "channel_id": "channel-0"
           },
@@ -174,6 +177,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "initiation-2",
             "base_denom": "utia",
             "channel_id": "channel-0"
           },
@@ -216,6 +220,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "initiation-2",
             "base_denom": "move/7dfcccb8d69af29d585165531eae5c558061d3e3bded2a121be3ef5e189e6b01",
             "channel_id": "channel-0"
           },

--- a/testnets/minimove/assetlist.json
+++ b/testnets/minimove/assetlist.json
@@ -21,7 +21,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "initiation-2"
           },
           "chain": {
             "bridge_id": "3"
@@ -62,6 +63,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "initiation-2",
             "base_denom": "ueth",
             "channel_id": "channel-0"
           },
@@ -102,6 +104,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "initiation-2",
             "base_denom": "uusdc",
             "channel_id": "channel-0"
           },
@@ -142,6 +145,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "initiation-2",
             "base_denom": "utia",
             "channel_id": "channel-0"
           },
@@ -182,6 +186,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "initiation-2",
             "base_denom": "move/7dfcccb8d69af29d585165531eae5c558061d3e3bded2a121be3ef5e189e6b01",
             "channel_id": "channel-0"
           },

--- a/testnets/miniwasm/assetlist.json
+++ b/testnets/miniwasm/assetlist.json
@@ -21,7 +21,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "initiation-2"
           },
           "chain": {
             "bridge_id": "2"
@@ -62,7 +63,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uusdc",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "initiation-2"
           },
           "chain": {
             "bridge_id": "2"
@@ -100,6 +102,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "initiation-2",
             "base_denom": "ueth",
             "channel_id": "channel-0"
           },
@@ -140,6 +143,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "initiation-2",
             "base_denom": "uusdc",
             "channel_id": "channel-0"
           },
@@ -180,6 +184,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "initiation-2",
             "base_denom": "utia",
             "channel_id": "channel-0"
           },
@@ -220,6 +225,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "initiation-2",
             "base_denom": "move/7dfcccb8d69af29d585165531eae5c558061d3e3bded2a121be3ef5e189e6b01",
             "channel_id": "channel-0"
           },

--- a/testnets/nuwarollup/assetlist.json
+++ b/testnets/nuwarollup/assetlist.json
@@ -21,7 +21,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "initiation-2"
           },
           "chain": {
             "bridge_id": "1152"

--- a/testnets/zaar/assetlist.json
+++ b/testnets/zaar/assetlist.json
@@ -49,7 +49,8 @@
           "type": "op",
           "counterparty": {
             "base_denom": "uinit",
-            "chain_name": "initia"
+            "chain_name": "initia",
+            "chain_id": "initiation-2"
           },
           "chain": {
             "bridge_id": "1048"
@@ -90,6 +91,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "initia",
+            "chain_id": "initiation-2",
             "base_denom": "uusdc",
             "channel_id": "channel-0"
           },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to specify that a "chain_id" field is required in the "counterparty" object for asset traces, with updated example JSON snippets.

* **New Features**
  * Added "chain_id" fields to all relevant "counterparty" objects in asset lists across mainnets and testnets, ensuring explicit chain identification in asset trace metadata.

* **Style**
  * Improved consistency and formatting in several asset list files for clarity and completeness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->