### PR TITLE
feat: add description max length

### DIFF
--- a/profile.schema.json
+++ b/profile.schema.json
@@ -31,7 +31,8 @@
     },
     "description": {
       "type": "string",
-      "description": "A longer description for the landing page"
+      "description": "A longer description for the landing page",
+      "maxLength": 140
     },
     "summary": {
       "type": "string",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The profile description field now has a maximum length of 140 characters. Users will be prevented from entering longer descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->