### PR TITLE
Update initia testnet chain configuration

### DIFF
--- a/testnets/initia/chain.json
+++ b/testnets/initia/chain.json
@@ -19,7 +19,10 @@
         "low_gas_price": 0.15,
         "average_gas_price": 0.15,
         "high_gas_price": 0.4
-      }
+      },
+      { "denom": "uusdc" },
+      { "denom": "ueth" },
+      { "denom": "utia" }
     ]
   },
   "staking": {


### PR DESCRIPTION
https://github.com/initia-labs/initia-registry/blob/main/mainnets/initia/chain.json#L25
Just like the Initia chain on mainnet declared tokens without a fixed price (technically, with variable price) as fee tokens in the file above, we added similar tokens on the testnet too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the list of supported fee tokens for the Initia testnet, allowing transactions with uusdc, ueth, and utia in addition to the existing uinit token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->