### PR TITLE
Add errors folder copy to API build process

### DIFF
--- a/_api/src/main.ts
+++ b/_api/src/main.ts
@@ -35,6 +35,11 @@ const srcProfilesDir = path.resolve(srcDir, "profiles")
 const distProfilesDir = path.resolve(distDir, "profiles")
 fs.copySync(srcProfilesDir, distProfilesDir)
 
+// Copy the errors directory to the dist directory
+const srcErrorsDir = path.resolve(srcDir, "errors")
+const distErrorsDir = path.resolve(distDir, "errors")
+fs.copySync(srcErrorsDir, distErrorsDir)
+
 // Update URLs in chain.json, assetlist.json and profile.json files
 // Example:
 // "https://raw.githubusercontent.com/initia-labs/initia-registry/main/initia/images/INIT.png"


### PR DESCRIPTION
## Summary
- Add functionality to copy the `errors` folder to the dist directory during API build process
- Follows the same pattern as existing `images` and `profiles` directory copying

## Test plan
- [x] Run `cd _api && npm run build` to verify errors folder is copied to dist
- [x] Verify errors directory structure is preserved in dist output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * The build process now ensures that all error files are included in the distribution package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->