### PR TITLE
feat(minievm&miniwasm): add upgrade info

### DIFF
--- a/testnets/minievm/chain.json
+++ b/testnets/minievm/chain.json
@@ -25,13 +25,13 @@
   },
   "codebase": {
     "git_repo": "https://github.com/initia-labs/minievm",
-    "recommended_version": "v1.0.2",
-    "compatible_versions": ["v1.0.2"],
+    "recommended_version": "v1.1.10",
+    "compatible_versions": ["v1.1.10"],
     "binaries": {
-      "linux/amd64": "https://github.com/initia-labs/minievm/releases/download/v1.0.2/minievm_v1.0.2_Linux_x86_64.tar.gz",
-      "linux/arm64": "https://github.com/initia-labs/minievm/releases/download/v1.0.2/minievm_v1.0.2_Linux_aarch64.tar.gz",
-      "darwin/amd64": "https://github.com/initia-labs/minievm/releases/download/v1.0.2/minievm_v1.0.2_Darwin_x86_64.tar.gz",
-      "darwin/arm64": "https://github.com/initia-labs/minievm/releases/download/v1.0.2/minievm_v1.0.2_Darwin_aarch64.tar.gz"
+      "linux/amd64": "https://github.com/initia-labs/minievm/releases/download/v1.1.10/minievm_v1.1.10_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/initia-labs/minievm/releases/download/v1.1.10/minievm_v1.1.10_Linux_aarch64.tar.gz",
+      "darwin/amd64": "https://github.com/initia-labs/minievm/releases/download/v1.1.10/minievm_v1.1.10_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/initia-labs/minievm/releases/download/v1.1.10/minievm_v1.1.10_Darwin_aarch64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://storage.googleapis.com/init-common-genesis/minievm-2/genesis.json"
@@ -191,6 +191,18 @@
           "linux/arm64": "https://github.com/initia-labs/minievm/releases/download/v1.0.2/minievm_v1.0.2_Linux_aarch64.tar.gz",
           "darwin/amd64": "https://github.com/initia-labs/minievm/releases/download/v1.0.2/minievm_v1.0.2_Darwin_x86_64.tar.gz",
           "darwin/arm64": "https://github.com/initia-labs/minievm/releases/download/v1.0.2/minievm_v1.0.2_Darwin_aarch64.tar.gz"
+        }
+      },
+      {
+        "name": "v1.1.9",
+        "recommended_version": "v1.1.10",
+        "compatible_versions": ["v1.1.10", "v1.1.9"],
+        "height": 9956720,
+        "binaries": {
+          "linux/amd64": "https://github.com/initia-labs/minievm/releases/download/v1.1.10/minievm_v1.1.10_Linux_x86_64.tar.gz",
+          "linux/arm64": "https://github.com/initia-labs/minievm/releases/download/v1.1.10/minievm_v1.1.10_Linux_aarch64.tar.gz",
+          "darwin/amd64": "https://github.com/initia-labs/minievm/releases/download/v1.1.10/minievm_v1.1.10_Darwin_x86_64.tar.gz",
+          "darwin/arm64": "https://github.com/initia-labs/minievm/releases/download/v1.1.10/minievm_v1.1.10_Darwin_aarch64.tar.gz"
         }
       }
     ]

--- a/testnets/miniwasm/chain.json
+++ b/testnets/miniwasm/chain.json
@@ -24,13 +24,13 @@
   },
   "codebase": {
     "git_repo": "https://github.com/initia-labs/miniwasm",
-    "recommended_version": "v1.0.2",
-    "compatible_versions": ["v1.0.2"],
+    "recommended_version": "v1.1.0",
+    "compatible_versions": ["v1.1.0"],
     "binaries": {
-      "linux/amd64": "https://github.com/initia-labs/miniwasm/releases/download/v1.0.2/miniwasm_v1.0.2_Linux_x86_64.tar.gz",
-      "linux/arm64": "https://github.com/initia-labs/miniwasm/releases/download/v1.0.2/miniwasm_v1.0.2_Linux_aarch64.tar.gz",
-      "darwin/amd64": "https://github.com/initia-labs/miniwasm/releases/download/v1.0.2/miniwasm_v1.0.2_Darwin_x86_64.tar.gz",
-      "darwin/arm64": "https://github.com/initia-labs/miniwasm/releases/download/v1.0.2/miniwasm_v1.0.2_Darwin_aarch64.tar.gz"
+      "linux/amd64": "https://github.com/initia-labs/miniwasm/releases/download/v1.1.0/miniwasm_v1.1.0_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/initia-labs/miniwasm/releases/download/v1.1.0/miniwasm_v1.1.0_Linux_aarch64.tar.gz",
+      "darwin/amd64": "https://github.com/initia-labs/miniwasm/releases/download/v1.1.0/miniwasm_v1.1.0_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/initia-labs/miniwasm/releases/download/v1.1.0/miniwasm_v1.1.0_Darwin_aarch64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://storage.googleapis.com/init-common-genesis/miniwasm-2/genesis.json"
@@ -94,6 +94,18 @@
           "linux/arm64": "https://github.com/initia-labs/miniwasm/releases/download/v1.0.2/miniwasm_v1.0.2_Linux_aarch64.tar.gz",
           "darwin/amd64": "https://github.com/initia-labs/miniwasm/releases/download/v1.0.2/miniwasm_v1.0.2_Darwin_x86_64.tar.gz",
           "darwin/arm64": "https://github.com/initia-labs/miniwasm/releases/download/v1.0.2/miniwasm_v1.0.2_Darwin_aarch64.tar.gz"
+        }
+      },
+      {
+        "name": "v1.1.0",
+        "recommended_version": "v1.1.0",
+        "compatible_versions": ["v1.1.0"],
+        "height": 9983000,
+        "binaries": {
+          "linux/amd64": "https://github.com/initia-labs/miniwasm/releases/download/v1.1.0/miniwasm_v1.1.0_Linux_x86_64.tar.gz",
+          "linux/arm64": "https://github.com/initia-labs/miniwasm/releases/download/v1.1.0/miniwasm_v1.1.0_Linux_aarch64.tar.gz",
+          "darwin/amd64": "https://github.com/initia-labs/miniwasm/releases/download/v1.1.0/miniwasm_v1.1.0_Darwin_x86_64.tar.gz",
+          "darwin/arm64": "https://github.com/initia-labs/miniwasm/releases/download/v1.1.0/miniwasm_v1.1.0_Darwin_aarch64.tar.gz"
         }
       }
     ]


### PR DESCRIPTION
## Description

Bump minievm to v1.1.9
Bump miniwasm to v1.1.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the recommended and compatible codebase versions for the Minievm and Miniwasm testnets.
  * Refreshed binary download links for all supported platforms to point to the latest releases.
  * Added new version entries reflecting recent updates and their activation block heights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->