### PR TITLE
Update civitia-1 gas price

### DIFF
--- a/mainnets/civitia/chain.json
+++ b/mainnets/civitia/chain.json
@@ -43,7 +43,7 @@
     "fee_tokens": [
       {
         "denom": "l2/2b2d36f666e98b9eecf70d6ec24b882b79f2c8e2af73f54f97b8b670dbb87605",
-        "fixed_min_gas_price": 0.015
+        "fixed_min_gas_price": 0.045
       }
     ]
   },


### PR DESCRIPTION
Update `civitia-1` gas price from `0.015` to `0.045`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the minimum gas price for the fee token on the network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->