### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -13,7 +13,7 @@ jobs:
   check_links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Link Checker
         id: lychee

--- a/.github/workflows/deploy_privnode.yml
+++ b/.github/workflows/deploy_privnode.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/npm_pr_initia_registry.yml
+++ b/.github/workflows/npm_pr_initia_registry.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: "20.x"

--- a/.github/workflows/npm_pr_types.yml
+++ b/.github/workflows/npm_pr_types.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: "20.x"

--- a/.github/workflows/npm_publish_initia_registry.yml
+++ b/.github/workflows/npm_publish_initia_registry.yml
@@ -12,7 +12,7 @@ jobs:
   publish_types:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/npm_publish_types.yml
+++ b/.github/workflows/npm_publish_types.yml
@@ -10,7 +10,7 @@ jobs:
   publish_types:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,5 +6,5 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/testnet-watcher.yml
+++ b/.github/workflows/testnet-watcher.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Get changed files
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: GCP Auth
         id: auth

--- a/.github/workflows/validate_assetlistjson.yml
+++ b/.github/workflows/validate_assetlistjson.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install JSON-Schema-Validator
         run: npm install -g jsonschema

--- a/.github/workflows/validate_chainjson.yml
+++ b/.github/workflows/validate_chainjson.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install JSON-Schema-Validator
         run: npm install -g jsonschema

--- a/.github/workflows/validate_data.yml
+++ b/.github/workflows/validate_data.yml
@@ -7,7 +7,7 @@ jobs:
     name: Validate Data
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/validate_errorjson.yml
+++ b/.github/workflows/validate_errorjson.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install JSON-Schema-Validator
         run: npm install -g jsonschema

--- a/.github/workflows/validate_profilejson.yml
+++ b/.github/workflows/validate_profilejson.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install JSON-Schema-Validator
         run: npm install -g jsonschema


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates. Requires runner v2.327.1+. Workflows compile the same.

More info: https://github.com/actions/checkout/releases/tag/v5.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GitHub Actions checkout step to v5 across CI workflows, including link checks, deployment, npm PR/publish processes, validation pipelines, pre-commit, and monitoring.
  * Standardized action versions across pipelines for consistency.
  * No changes to workflow logic, inputs, or application behavior; all other steps remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->