### PR TITLE
Update MilkyWay coingecko_id to milkyway-2

### DIFF
--- a/mainnets/initia/assetlist.json
+++ b/mainnets/initia/assetlist.json
@@ -1204,7 +1204,7 @@
       "display": "MILK",
       "name": "MilkyWay Native Token",
       "symbol": "MILK",
-      "coingecko_id": "milkyway",
+      "coingecko_id": "milkyway-2",
       "traces": [
         {
           "type": "ibc",

--- a/mainnets/moo/assetlist.json
+++ b/mainnets/moo/assetlist.json
@@ -85,7 +85,7 @@
       "display": "MILK",
       "name": "MilkyWay Native Token",
       "symbol": "MILK",
-      "coingecko_id": "milkyway",
+      "coingecko_id": "milkyway-2",
       "traces": [
         {
           "type": "ibc",


### PR DESCRIPTION
The coingecko_id for MILK token has been updated from "milkyway" to "milkyway-2" to match the correct CoinGecko listing identifier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected market data mapping for the MilkyWay (MILK) token across multiple mainnets, ensuring accurate price, charts, and market cap data.
  * Fixes incorrect or missing valuations in portfolios, fiat conversions, and totals involving MILK.
  * Token details, watchlists, and analytics now reflect up-to-date information for MILK without changes to its name, symbol, or visuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->