### PR TITLE
feat: indexer api for all rollups

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -533,6 +533,14 @@
           },
           "minContains": 1,
           "description": "Evm json rpc websocket uri"
+        },
+        "indexer": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/secureEndpoint"
+          },
+          "minContains": 1,
+          "description": "Indexer uri"
         }
       },
       "additionalProperties": false

--- a/mainnets/bfb/chain.json
+++ b/mainnets/bfb/chain.json
@@ -72,6 +72,11 @@
       {
         "address": "wss://jsonrpc-ws-bfb-1.anvil.europe-west.initia.xyz"
       }
+    ],
+    "indexer": [
+      {
+        "address": "https://rest-bfb-1.anvil.europe-west.initia.xyz"
+      }
     ]
   },
   "key_algos": ["initia_ethsecp256k1", "secp256k1"],

--- a/mainnets/civitia/chain.json
+++ b/mainnets/civitia/chain.json
@@ -35,6 +35,11 @@
       {
         "address": "grpc-civitia-1.anvil.asia-southeast.initia.xyz:443"
       }
+    ],
+    "indexer": [
+      {
+        "address": "https://rollytics-api-civitia-1.anvil.asia-southeast.initia.xyz"
+      }
     ]
   },
   "key_algos": ["initia_ethsecp256k1", "secp256k1"],

--- a/mainnets/echelon/chain.json
+++ b/mainnets/echelon/chain.json
@@ -39,6 +39,11 @@
       {
         "address": "grpc-echelon-1.anvil.asia-southeast.initia.xyz:443"
       }
+    ],
+    "indexer": [
+      {
+        "address": "https://rollytics-api-echelon-1.anvil.asia-southeast.initia.xyz"
+      }
     ]
   },
   "key_algos": ["initia_ethsecp256k1", "secp256k1"],

--- a/mainnets/embr/chain.json
+++ b/mainnets/embr/chain.json
@@ -46,6 +46,11 @@
       {
         "address": "wss://jsonrpc-ws-embrmainnet-1.anvil.asia-southeast.initia.xyz"
       }
+    ],
+    "indexer": [
+      {
+        "address": "https://rollytics-api-embrmainnet-1.anvil.asia-southeast.initia.xyz"
+      }
     ]
   },
   "key_algos": ["initia_ethsecp256k1", "secp256k1"],

--- a/mainnets/inertia/chain.json
+++ b/mainnets/inertia/chain.json
@@ -42,6 +42,11 @@
         "address": "grpc.inrt.fi:443",
         "provider": "Inertia"
       }
+    ],
+    "indexer": [
+      {
+        "address": "https://rest.inrt.fi"
+      }
     ]
   },
   "explorers": [

--- a/mainnets/ingnetwork/chain.json
+++ b/mainnets/ingnetwork/chain.json
@@ -46,6 +46,11 @@
       {
         "address": "wss://jsonrpc-ws-ingnetwork-1.anvil.asia-southeast.initia.xyz"
       }
+    ],
+    "indexer": [
+      {
+        "address": "https://rollytics-api-ingnetwork-1.anvil.asia-southeast.initia.xyz"
+      }
     ]
   },
   "key_algos": ["initia_ethsecp256k1", "secp256k1"],

--- a/mainnets/intergaze/chain.json
+++ b/mainnets/intergaze/chain.json
@@ -33,6 +33,11 @@
       {
         "address": "grpc.intergaze-apis.com:443"
       }
+    ],
+    "indexer": [
+      {
+        "address": "https://rollytics-api-intergaze-1.anvil.asia-southeast.initia.xyz"
+      }
     ]
   },
   "key_algos": ["initia_ethsecp256k1", "secp256k1"],

--- a/mainnets/moo/chain.json
+++ b/mainnets/moo/chain.json
@@ -35,6 +35,11 @@
       {
         "address": "grpc-moo-1.anvil.asia-southeast.initia.xyz:443"
       }
+    ],
+    "indexer": [
+      {
+        "address": "https://rollytics-api-moo-1.anvil.asia-southeast.initia.xyz"
+      }
     ]
   },
   "key_algos": ["initia_ethsecp256k1", "secp256k1"],

--- a/mainnets/rave/chain.json
+++ b/mainnets/rave/chain.json
@@ -46,6 +46,11 @@
       {
         "address": "wss://jsonrpc-ws-rave-1.anvil.asia-southeast.initia.xyz"
       }
+    ],
+    "indexer": [
+      {
+        "address": "https://rollytics-api-rave-1.anvil.asia-southeast.initia.xyz"
+      }
     ]
   },
   "key_algos": ["initia_ethsecp256k1", "secp256k1"],

--- a/mainnets/rena/chain.json
+++ b/mainnets/rena/chain.json
@@ -35,6 +35,11 @@
       {
         "address": "grpc-rena-nuwa-1.anvil.asia-southeast.initia.xyz:443"
       }
+    ],
+    "indexer": [
+      {
+        "address": "https://rollytics-api-rena-nuwa-1.anvil.asia-southeast.initia.xyz"
+      }
     ]
   },
   "key_algos": ["initia_ethsecp256k1", "secp256k1"],

--- a/mainnets/yominet/chain.json
+++ b/mainnets/yominet/chain.json
@@ -91,6 +91,11 @@
       {
         "address": "wss://jsonrpc-ws-yominet-1.anvil.asia-southeast.initia.xyz"
       }
+    ],
+    "indexer": [
+      {
+        "address": "https://rollytics-api-yominet-1.anvil.asia-southeast.initia.xyz"
+      }
     ]
   },
   "key_algos": ["initia_ethsecp256k1", "secp256k1"],

--- a/mainnets/zaar/chain.json
+++ b/mainnets/zaar/chain.json
@@ -46,6 +46,11 @@
       {
         "address": "wss://jsonrpc-ws-zaar-mainnet-1.anvil.asia-southeast.initia.xyz"
       }
+    ],
+    "indexer": [
+      {
+        "address": "https://rollytics-api-zaar-mainnet-1.anvil.asia-southeast.initia.xyz"
+      }
     ]
   },
   "key_algos": ["initia_ethsecp256k1", "secp256k1"],

--- a/testnets/civitia/chain.json
+++ b/testnets/civitia/chain.json
@@ -33,6 +33,11 @@
       {
         "address": "grpc-landlord-3.anvil.asia-southeast.initia.xyz:443"
       }
+    ],
+    "indexer": [
+      {
+        "address": "https://rollytics-api-landlord-3.anvil.asia-southeast.initia.xyz"
+      }
     ]
   },
   "key_algos": ["secp256k1"],

--- a/testnets/contro/chain.json
+++ b/testnets/contro/chain.json
@@ -70,6 +70,11 @@
       {
         "address": "grpc-contro-testnet-1.anvil.europe-west.initia.xyz:443"
       }
+    ],
+    "indexer": [
+      {
+        "address": "https://rollytics-api-contro-testnet-1.anvil.europe-west.initia.xyz"
+      }
     ]
   },
   "explorers": [

--- a/testnets/embr_old/chain.json
+++ b/testnets/embr_old/chain.json
@@ -63,6 +63,11 @@
       {
         "address": "wss://jsonrpc-ws-embr-1.anvil.asia-southeast.initia.xyz"
       }
+    ],
+    "indexer": [
+      {
+        "address": "https://rollytics-api-embr-1.anvil.asia-southeast.initia.xyz"
+      }
     ]
   },
   "explorers": [

--- a/testnets/ingnetworktest/chain.json
+++ b/testnets/ingnetworktest/chain.json
@@ -44,6 +44,11 @@
       {
         "address": "wss://jsonrpc-ws-ingnetwork-test-1.anvil.asia-southeast.initia.xyz"
       }
+    ],
+    "indexer": [
+      {
+        "address": "https://rollytics-api-ingnetwork-test-1.anvil.asia-southeast.initia.xyz"
+      }
     ]
   },
   "explorers": [

--- a/testnets/milkyway/chain.json
+++ b/testnets/milkyway/chain.json
@@ -45,6 +45,11 @@
         "address": "grpc-glados-4.anvil.asia-southeast.initia.xyz:443",
         "provider": "Initia Labs"
       }
+    ],
+    "indexer": [
+      {
+        "address": "https://rollytics-api-glados-4.anvil.asia-southeast.initia.xyz"
+      }
     ]
   },
   "explorers": [

--- a/testnets/minievm/chain.json
+++ b/testnets/minievm/chain.json
@@ -260,6 +260,11 @@
         "address": "https://json-rpc-websocket.minievm-2.initia.xyz",
         "provider": "Initia Labs"
       }
+    ],
+    "indexer": [
+      {
+        "address": "https://rest.minievm-2.initia.xyz"
+      }
     ]
   },
   "explorers": [

--- a/testnets/minimove/chain.json
+++ b/testnets/minimove/chain.json
@@ -163,6 +163,11 @@
         "authorizedUser": "skip",
         "indexForSkip": 0
       }
+    ],
+    "indexer": [
+      {
+        "address": "https://rest.minimove-2.initia.xyz"
+      }
     ]
   },
   "explorers": [

--- a/testnets/miniwasm/chain.json
+++ b/testnets/miniwasm/chain.json
@@ -151,6 +151,11 @@
         "authorizedUser": "skip",
         "indexForSkip": 0
       }
+    ],
+    "indexer": [
+      {
+        "address": "https://rest.miniwasm-2.initia.xyz"
+      }
     ]
   },
   "explorers": [

--- a/testnets/split/chain.json
+++ b/testnets/split/chain.json
@@ -44,6 +44,11 @@
       {
         "address": "wss://jsonrpc-ws-split-2.anvil.asia-southeast.initia.xyz"
       }
+    ],
+    "indexer": [
+      {
+        "address": "https://rollytics-api-split-2.anvil.asia-southeast.initia.xyz"
+      }
     ]
   },
   "explorers": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced “indexer” API support with secure endpoint requirements.
  * Added indexer endpoints for mainnets: bfb, civitia, echelon, embr, inertia, ingnetwork, intergaze, moo, rave, rena, yominet, zaar.
  * Added indexer endpoints for testnets: civitia, contro, embr_old, ingnetworktest, milkyway, minievm, minimove, miniwasm, split.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->