### PR TITLE
feat: add init-usdc lp to mainnet assetlist

### DIFF
--- a/assetlist.schema.json
+++ b/assetlist.schema.json
@@ -47,6 +47,11 @@
           "type": "string",
           "description": "[OPTIONAL] The address of the asset. Only required for type_asset : cw20, snip20"
         },
+        "token_type": {
+          "type": "string",
+          "enum": ["lp"],
+          "description": "[OPTIONAL] The type of token."
+        },
         "base": {
           "type": "string",
           "description": "The base unit of the asset. Must be in denom_units."

--- a/mainnets/initia/assetlist.json
+++ b/mainnets/initia/assetlist.json
@@ -328,6 +328,33 @@
       }
     },
     {
+      "description": "Liquidity Pool Token for USDC-INIT trading pair on Initia DEX",
+      "denom_units": [
+        {
+          "denom": "USDC-INIT LP",
+          "exponent": 6
+        },
+        {
+          "denom": "move/543b35a39cfadad3da3c23249c474455d15efd2f94f849473226dee8a3c7a9e1",
+          "exponent": 0
+        }
+      ],
+      "base": "move/543b35a39cfadad3da3c23249c474455d15efd2f94f849473226dee8a3c7a9e1",
+      "display": "USDC-INIT LP",
+      "name": "USDC-INIT LP",
+      "symbol": "USDC-INIT LP",
+      "token_type": "lp",
+      "coingecko_id": "",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/USDC-INIT.png"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/USDC-INIT.png"
+      }
+    },
+    {
       "description": "Drop staked INIT-USDC LPT",
       "denom_units": [
         {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an optional token_type field to asset metadata with support for the value "lp".
  - Included the USDC-INIT LP token in the asset list with base/display/name/symbol set to “USDC-INIT LP,” appropriate denom units, and an associated image/logo.
  - This enables clearer identification and display of liquidity pool tokens in supported interfaces without affecting existing assets or required fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->