### PR TITLE
feat: add l1 indexer APIs

### DIFF
--- a/mainnets/initia/chain.json
+++ b/mainnets/initia/chain.json
@@ -174,6 +174,12 @@
         "address": "https://initia-grpc.cosmosspaces.zone",
         "provider": "CosmosSpaces"
       }
+    ],
+    "indexer": [
+      {
+        "address": "https://indexer.initia.xyz",
+        "provider": "Initia Labs"
+      }
     ]
   },
   "explorers": [

--- a/testnets/initia/chain.json
+++ b/testnets/initia/chain.json
@@ -173,6 +173,12 @@
         "provider": "Initia Labs",
         "authorizedUser": "skip"
       }
+    ],
+    "indexer": [
+      {
+        "address": "https://indexer.initiation-2.initia.xyz",
+        "provider": "Initia Labs"
+      }
     ]
   },
   "explorers": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added indexer API endpoints for Initia mainnet and testnet to enhance on-chain data access.
  * Mainnet: https://indexer.initia.xyz; Testnet: https://indexer.initiation-2.initia.xyz (provider: Initia Labs).
  * Endpoints are discoverable in network configs for faster indexing and querying of accounts, transactions, and blocks.
  * No changes to existing RPC/REST/GRPC endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->