### PR TITLE
fix: intergaze doesn't have rollytics yet, change to rest

### DIFF
--- a/mainnets/intergaze/chain.json
+++ b/mainnets/intergaze/chain.json
@@ -36,7 +36,7 @@
     ],
     "indexer": [
       {
-        "address": "https://rollytics-api-intergaze-1.anvil.asia-southeast.initia.xyz"
+        "address": "https://rest.intergaze-apis.com"
       }
     ]
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated the Intergaze mainnet indexer endpoint to a new REST domain to ensure continued connectivity and more reliable on-chain data retrieval.
  * This change aims to improve response times and reduce potential regional outages impacting data queries.
  * No user action required; functionality remains the same with improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->