### PR TITLE
fix: decrease resource allocation for privnode

### DIFF
--- a/.github/workflows/utility/deploy_privnode.js
+++ b/.github/workflows/utility/deploy_privnode.js
@@ -86,6 +86,7 @@ async function deployPrivnodes(idToken) {
             const p2pPeers = data.peer_infos || [];
             const trustedPeers = p2pPeers.map(p => p.split('@')[0]);
             const baseRegion = data.base_region || process.env.REGION;
+            const isMainnet = data.l1_chain_id === "interwoven-1";
 
             const payload = {
                 image: { privnode: image },
@@ -99,8 +100,8 @@ async function deployPrivnodes(idToken) {
                 },
                 resources: {
                     privnode: {
-                        cpu: "8",
-                        memory: "32Gi"
+                        cpu: "4",
+                        memory: "8Gi"
                     }
                 },
                 storage: {
@@ -109,6 +110,12 @@ async function deployPrivnodes(idToken) {
                     }
                 }
             };
+
+            // use more resources for mainnet deployments
+            if (isMainnet) {
+                payload.resources.privnode.cpu = "6";
+                payload.resources.privnode.memory = "16Gi";
+            }
 
             const postUrl = `${url}/privnode`;
             await axios.post(postUrl, payload, { headers });


### PR DESCRIPTION
## Summary
We are standardizing and reducing resource allocation for all Anvil nodes to optimize usage. This change applies the new allocation rules here.

### Changes

- Mainnet nodes:
   CPU: 8 → 6
   Memory: 32GB → 16GB

- Testnet nodes:
   CPU: 8 → 4
   Memory: 32GB → 8GB

### Rationale
This adjustment aligns Anvil nodes with our updated infrastructure policy, ensuring more efficient resource usage without compromising stability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deployment now adjusts privnode resources by network: mainnet vs. non-mainnet.
  * Reduced default privnode requirements to CPU 4, Memory 8Gi for non-mainnet environments to lower footprint.
  * Mainnet privnode now requests CPU 6, Memory 16Gi to enhance stability under load.
  * Changes apply only to privnode resources; no other deployment parameters affected.
  * No functional changes to user-facing features; infrastructure sizing only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->