### PR TITLE
use op init denom on Pokerking testnet

### DIFF
--- a/testnets/pokerkings/assetlist.json
+++ b/testnets/pokerkings/assetlist.json
@@ -29,16 +29,14 @@
       },
       "traces": [
         {
-          "type": "ibc",
+          "type": "op",
           "counterparty": {
             "chain_name": "initia",
             "chain_id": "initiation-2",
-            "base_denom": "uinit",
-            "channel_id": "channel-2803"
+            "base_denom": "uinit"
           },
           "chain": {
-            "channel_id": "channel-0",
-            "path": "transfer/channel-0/uinit"
+            "bridge_id": "1325"
           }
         }
       ]


### PR DESCRIPTION
- use op init denom

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed native token identification on the PokerKings testnet by aligning token reference and transfer trace type to the current L2/bridge format, improving balance accuracy and transaction handling in wallets and apps.

* **Chores**
  * Updated PokerKings testnet asset configuration and trace metadata to reflect the new L2 token reference and bridge setup for smoother interoperability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->