### PR TITLE
Use Node 22 in workflows

### DIFF
--- a/.github/workflows/sync_images.yml
+++ b/.github/workflows/sync_images.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 19.6.0
+          node-version: 22
 
       - name: Run code to Sync Images
         working-directory: ./.github/workflows/utility

--- a/.github/workflows/validate_data.yml
+++ b/.github/workflows/validate_data.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
 
       - name: Get changed files (chain.json / assetlist.json)
         id: changed


### PR DESCRIPTION
Switch CI to Node 22 (exact major) for consistent, reproducible runs.