### PR TITLE
feat: add mainnet chain id on profile.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,7 @@ An example assetlist json contains the following structure:
 | `$schema`                   | `string (URL/path)` | Yes           | Path or URL to the profile schema (e.g. `../../profile.schema.json`).               |
 | `name`                      | `string`            | Yes           | The chain name matching `chain_name` in other JSON files.                           |
 | `pretty_name`               | `string`            | Yes           | A human-readable chain name (e.g. “Kamigotchi”).                                    |
+| `chain_id`                  | `string`            | Optional      | Mainnet chain id                                                                    |
 | `category`                  | `string`            | Optional      | Broad classification of the chain (e.g. “Gaming”, “DeFi”, “Infrastructure”).        |
 | `l2`                        | `boolean`           | Optional      | Indicates whether this chain is a Layer 2 chain.                                    |
 | `description`               | `string`            | Optional      | A detailed description or tagline for the chain.                                    |

--- a/profile.schema.json
+++ b/profile.schema.json
@@ -17,6 +17,9 @@
     "pretty_name": {
       "type": "string"
     },
+    "chain_id": {
+      "type": "string"
+    },
     "category": {
       "type": "string",
       "enum": ["DeFi", "Social", "NFT", "Gaming", "Portfolio", "AI", "Others"]

--- a/profiles/bfb.json
+++ b/profiles/bfb.json
@@ -2,6 +2,7 @@
   "$schema": "../profile.schema.json",
   "name": "bfb",
   "pretty_name": "Battle for Blockchain",
+  "chain_id": "bfb-1",
   "category": "Gaming",
   "l2": true,
   "description": "Fully onchain battle world, where value gets redistributed based on players performance.",

--- a/profiles/civitia.json
+++ b/profiles/civitia.json
@@ -2,6 +2,7 @@
   "$schema": "../profile.schema.json",
   "name": "civitia",
   "pretty_name": "Civitia",
+  "chain_id": "civitia-1",
   "category": "Gaming",
   "l2": true,
   "description": "Mint cities, collect yield, and collaborate within communities to acquire control of the planet.",

--- a/profiles/echelon.json
+++ b/profiles/echelon.json
@@ -2,6 +2,7 @@
   "$schema": "../profile.schema.json",
   "name": "echelon",
   "pretty_name": "Echelon",
+  "chain_id": "echelon-1",
   "category": "DeFi",
   "l2": true,
   "description": "A highly efficient money market connecting liquidity and supercharging yields with LST, RWA, and stablecoin backed lending strategies.",

--- a/profiles/embr.json
+++ b/profiles/embr.json
@@ -2,6 +2,7 @@
   "$schema": "../profile.schema.json",
   "name": "embr",
   "pretty_name": "Embr.fun",
+  "chain_id": "embrmainnet-1",
   "category": "DeFi",
   "l2": true,
   "description": "A novel launchpad where users can win big by focusing liquidity into the best memes.",

--- a/profiles/inertia.json
+++ b/profiles/inertia.json
@@ -2,6 +2,7 @@
   "$schema": "../profile.schema.json",
   "name": "inertia",
   "pretty_name": "Inertia",
+  "chain_id": "inertia-2",
   "category": "DeFi",
   "l2": true,
   "description": "The interwoven lending protocol for the modular ecosystem.",

--- a/profiles/ingnetwork.json
+++ b/profiles/ingnetwork.json
@@ -2,6 +2,7 @@
   "$schema": "../profile.schema.json",
   "name": "ingnetwork",
   "pretty_name": "ING Network",
+  "chain_id": "ingnetwork-1",
   "category": "AI",
   "tags": [],
   "l2": true,

--- a/profiles/intergaze.json
+++ b/profiles/intergaze.json
@@ -2,6 +2,7 @@
   "$schema": "../profile.schema.json",
   "name": "intergaze",
   "pretty_name": "Intergaze",
+  "chain_id": "intergaze-1",
   "category": "NFT",
   "l2": true,
   "description": "The Launchpad and Marketplace for Interwoven NFTs",

--- a/profiles/moo.json
+++ b/profiles/moo.json
@@ -2,6 +2,7 @@
   "$schema": "../profile.schema.json",
   "name": "moo",
   "pretty_name": "MilkyWay",
+  "chain_id": "moo-1",
   "category": "DeFi",
   "l2": true,
   "description": "The Modular Staking Portal",

--- a/profiles/rave.json
+++ b/profiles/rave.json
@@ -2,6 +2,7 @@
   "$schema": "../profile.schema.json",
   "name": "rave",
   "pretty_name": "Rave",
+  "chain_id": "rave-1",
   "category": "DeFi",
   "l2": true,
   "description": "The pioneer quanto perpetuals protocol: trade anything with everything.",

--- a/profiles/rena.json
+++ b/profiles/rena.json
@@ -2,6 +2,7 @@
   "$schema": "../profile.schema.json",
   "name": "rena",
   "pretty_name": "Rena",
+  "chain_id": "rena-nuwa-1",
   "category": "AI",
   "tags": ["TEE", "Infra"],
   "l2": true,

--- a/profiles/yominet.json
+++ b/profiles/yominet.json
@@ -2,6 +2,7 @@
   "$schema": "../profile.schema.json",
   "name": "yominet",
   "pretty_name": "Yominet",
+  "chain_id": "yominet-1",
   "category": "Gaming",
   "l2": true,
   "description": "The first economically independent virtual world living onchain. Home to the Kamigotchi.",

--- a/profiles/zaar.json
+++ b/profiles/zaar.json
@@ -2,6 +2,7 @@
   "$schema": "../profile.schema.json",
   "name": "zaar",
   "pretty_name": "Zaar",
+  "chain_id": "zaar-mainnet-1",
   "category": "Gaming",
   "l2": true,
   "description": "The Fun Network, where Degeneracy comes to play.",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced optional chain_id metadata (mainnet chain ID) across profiles and asset lists.
  - Populated chain_id for multiple networks: bfb, civitia, echelon, embr, inertia, ingnetwork, intergaze, moo, rave, rena, yominet, and zaar.

- Documentation
  - Updated documentation to describe the new optional chain_id field in asset and profile structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->