### PR TITLE
feat: Add IBC migration info for Inertia testnet

### DIFF
--- a/testnets/inertia/assetlist.json
+++ b/testnets/inertia/assetlist.json
@@ -221,8 +221,8 @@
             "channel_id": "channel-3079"
           },
           "chain": {
-            "channel_id": "channel-2",
-            "path": "transfer/channel-2/move/f3718591c10dbebe4891b242e03fddaaaf24ccc2b6bf6d8606d3c5828898ace0"
+            "channel_id": "channel-0",
+            "path": "transfer/channel-0/move/f3718591c10dbebe4891b242e03fddaaaf24ccc2b6bf6d8606d3c5828898ace0"
           }
         }
       ],
@@ -262,8 +262,8 @@
             "channel_id": "channel-3079"
           },
           "chain": {
-            "channel_id": "channel-2",
-            "path": "transfer/channel-2/move/c7387e7bff428eac4ed0f29695f40180f6d6f432d862ce5f14d9032b1e9c1336"
+            "channel_id": "channel-0",
+            "path": "transfer/channel-0/move/c7387e7bff428eac4ed0f29695f40180f6d6f432d862ce5f14d9032b1e9c1336"
           }
         }
       ],

--- a/testnets/inertia/chain.json
+++ b/testnets/inertia/chain.json
@@ -79,12 +79,12 @@
       {
         "chain_id": "initiation-2",
         "port_id": "transfer",
-        "channel_id": "channel-2",
+        "channel_id": "channel-0",
         "version": "ics20-1"
       },
       {
         "chain_id": "initiation-2",
-        "port_id": "wasm.init1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtq7947m6",
+        "port_id": "nft-transfer",
         "channel_id": "channel-1",
         "version": "{\"fee_version\":\"ics29-1\",\"app_version\":\"ics721-1\"}"
       }

--- a/testnets/initia/chain.json
+++ b/testnets/initia/chain.json
@@ -270,7 +270,7 @@
       },
       {
         "chain_id": "inertiation-13",
-        "port_id": "wasm.init1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtq7947m6",
+        "port_id": "nft-transfer",
         "channel_id": "channel-3080",
         "version": "{\"fee_version\":\"ics29-1\",\"app_version\":\"ics721-1\"}"
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated testnet configuration: chain identifiers and IBC channel references were revised to match current network topology.
  * Adjusted asset trace entries to point to the updated channels and reflect the changed version encoding for certain token transfer metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->