### PR TITLE
fix(cabal): correct explorer URLs

### DIFF
--- a/mainnets/cabal/chain.json
+++ b/mainnets/cabal/chain.json
@@ -54,9 +54,9 @@
   "explorers": [
     {
       "kind": "initia scan",
-      "url": "https://scan.falseinitia.xyz/cabal-1",
-      "tx_page": "https://scan.falseinitia.xyz/cabal-1/txs/${txHash}",
-      "account_page": "https://scan.falseinitia.xyz/cabal-1/accounts/${accountAddress}"
+      "url": "https://scan.initia.xyz/cabal-1",
+      "tx_page": "https://scan.initia.xyz/cabal-1/txs/${txHash}",
+      "account_page": "https://scan.initia.xyz/cabal-1/accounts/${accountAddress}"
     }
   ],
   "key_algos": ["initia_ethsecp256k1"],


### PR DESCRIPTION
- Replace scan.falseinitia.xyz with scan.initia.xyz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Cabal chain explorer endpoints to use the latest scanner service addresses, improving access to blockchain data and transaction information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->