### PR TITLE
chore: set `min-release-age` for supply chain protection

### DIFF
--- a/_packages/initia-registry/.npmrc
+++ b/_packages/initia-registry/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/_packages/types/.npmrc
+++ b/_packages/types/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm package release configuration to enforce a minimum release age of 7 days across package registries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->