### PR TITLE
fix: remove api initia

### DIFF
--- a/_packages/initia-registry/src/mainnet/initia/chain.ts
+++ b/_packages/initia-registry/src/mainnet/initia/chain.ts
@@ -59,12 +59,6 @@ const info: Chain = {
         authorizedUser: "skip",
       },
     ],
-    api: [
-      {
-        address: "https://api.initia.xyz",
-        provider: "Initia Labs",
-      },
-    ],
     grpc: [
       {
         address: "grpc.initia.xyz:443",

--- a/_packages/initia-registry/src/testnet/initia/chain.ts
+++ b/_packages/initia-registry/src/testnet/initia/chain.ts
@@ -55,12 +55,6 @@ const info: Chain = {
         authorizedUser: "skip",
       },
     ],
-    api: [
-      {
-        address: "https://api.testnet.initia.xyz",
-        provider: "Initia Labs",
-      },
-    ],
     grpc: [
       {
         address: "grpc.testnet.initia.xyz:443",

--- a/mainnets/initia/chain.json
+++ b/mainnets/initia/chain.json
@@ -142,12 +142,6 @@
         "authorizedUser": "skip"
       }
     ],
-    "api": [
-      {
-        "address": "https://api.initia.xyz",
-        "provider": "Initia Labs"
-      }
-    ],
     "grpc": [
       {
         "address": "grpc.initia.xyz:443",

--- a/testnets/initia/chain.json
+++ b/testnets/initia/chain.json
@@ -157,12 +157,6 @@
         "authorizedUser": "skip"
       }
     ],
-    "api": [
-      {
-        "address": "https://api.testnet.initia.xyz",
-        "provider": "Initia Labs"
-      }
-    ],
     "grpc": [
       {
         "address": "grpc.testnet.initia.xyz:443",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed API endpoint entries from the Initia registry for mainnet and testnet configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->