### PR TITLE
chore(rave): set status to hidden

### DIFF
--- a/profiles/rave.json
+++ b/profiles/rave.json
@@ -8,7 +8,7 @@
   "description": "The pioneer quanto perpetuals protocol: trade anything with everything.",
   "logo": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/rave.png",
   "color": "#2962ff",
-  "status": "live",
+  "status": "hidden",
   "vip": {
     "forum_url": "https://forum.initia.xyz/t/whitelist-rave-on-vip/61",
     "actions": [


### PR DESCRIPTION
The Rave rollup is being sunset. Hide the profile from ecosystem listings now, while the chain entry (`mainnets/rave/`) stays until the chain is actually shut down — see the companion PR #845 that removes it.