### PR TITLE
fix: correct Celestia TIA counterparty channels

### DIFF
--- a/mainnets/echelon/assetlist.json
+++ b/mainnets/echelon/assetlist.json
@@ -173,7 +173,7 @@
             "chain_name": "celestia",
             "chain_id": "celestia",
             "base_denom": "utia",
-            "channel_id": "channel-78"
+            "channel_id": "channel-86"
           },
           "chain": {
             "channel_id": "channel-10",

--- a/mainnets/inertia/assetlist.json
+++ b/mainnets/inertia/assetlist.json
@@ -65,7 +65,7 @@
             "chain_name": "celestia",
             "chain_id": "celestia",
             "base_denom": "utia",
-            "channel_id": "channel-78"
+            "channel_id": "channel-86"
           },
           "chain": {
             "channel_id": "channel-10",

--- a/mainnets/yominet/assetlist.json
+++ b/mainnets/yominet/assetlist.json
@@ -137,7 +137,7 @@
             "chain_name": "celestia",
             "chain_id": "celestia",
             "base_denom": "utia",
-            "channel_id": "channel-78"
+            "channel_id": "channel-86"
           },
           "chain": {
             "channel_id": "channel-10",


### PR DESCRIPTION
Updates the duplicated Celestia TIA traces on Inertia, Yominet, and Echelon from Celestia channel-78 to channel-86.

These traces all describe the same IBC hop:
- Celestia utia transferred over Initia transfer/channel-10
- Initia channel-10's counterparty is Celestia transfer/channel-86

## Verification

```
curl -fsS https://rest.initia.xyz/ibc/core/channel/v1/channels/channel-10/ports/transfer | jq '.channel.counterparty'
```

### Result
```
{
  "port_id": "transfer",
  "channel_id": "channel-86"
}
```

## Relevance
This confirms the Initia-side channel used in the asset traces, channel-10, points to Celestia channel-86.

## Verification
```
curl -fsS https://api.celestia.pops.one/ibc/core/channel/v1/channels/channel-86/ports/transfer | jq '.channel.counterparty'
```

## Result
```
{
  "port_id": "transfer",
  "channel_id": "channel-10"
}
```

## Relevance
This confirms Celestia channel-86 is the reciprocal channel for Initia transfer/channel-10.

## Verification
```
curl -i https://api.celestia.pops.one/ibc/core/channel/v1/channels/channel-78/ports/transfer
```

## Result
```
HTTP/1.1 404 Not Found
{"code":5,"message":"port-id: transfer, channel-id channel-78: channel not found","details":[]}
```

## Relevance
This confirms channel-78 is not a valid Celestia transfer channel for this trace, so the existing L2 assetlist entries were stale.