### PR TITLE
feat: add Injective USDC across Initia and rollups

### DIFF
--- a/mainnets/cabal/assetlist.json
+++ b/mainnets/cabal/assetlist.json
@@ -177,6 +177,74 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/USDC.png"
       }
+    },
+    {
+      "description": "USDC from Injective",
+      "denom_units": [
+        {
+          "denom": "evm/f27248Fc3C306cd9F9C72BDb768bc131C98694Cc",
+          "exponent": 0
+        },
+        {
+          "denom": "USDC.inj",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "erc20",
+      "address": "0xf27248Fc3C306cd9F9C72BDb768bc131C98694Cc",
+      "base": "evm/f27248Fc3C306cd9F9C72BDb768bc131C98694Cc",
+      "display": "USDC.inj",
+      "name": "USD Coin (Injective)",
+      "symbol": "USDC.inj",
+      "coingecko_id": "usd-coin",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "injective",
+            "chain_id": "injective-1",
+            "base_denom": "erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a",
+            "channel_id": "channel-488"
+          },
+          "chain": {
+            "channel_id": "channel-113",
+            "path": "transfer/channel-113/erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a"
+          }
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "initia",
+            "chain_id": "interwoven-1",
+            "base_denom": "ibc/A64E1233F240D4B886413A12CF0300D6EC6FA0554DBD176119C399D0E2CA8048",
+            "channel_id": "channel-97"
+          },
+          "chain": {
+            "channel_id": "channel-0",
+            "path": "transfer/channel-0/transfer/channel-113/erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a"
+          }
+        },
+        {
+          "type": "wrapped",
+          "counterparty": {
+            "chain_name": "cabal",
+            "chain_id": "cabal-1",
+            "base_denom": "ibc/66AD18D1572EF88D509E831201FDFAFC109CED28E17929B422B47CAEB6836792"
+          },
+          "chain": {
+            "contract": "0xB24905344757Bf9CE80442fE1245A9019ee2d749"
+          },
+          "provider": "Decimal Wrapper"
+        }
+      ],
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/USDC.png"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/USDC.png"
+      }
     }
   ]
 }

--- a/mainnets/echelon/assetlist.json
+++ b/mainnets/echelon/assetlist.json
@@ -150,6 +150,60 @@
       }
     },
     {
+      "description": "USDC from Injective",
+      "denom_units": [
+        {
+          "denom": "ibc/66AD18D1572EF88D509E831201FDFAFC109CED28E17929B422B47CAEB6836792",
+          "exponent": 0
+        },
+        {
+          "denom": "USDC.inj",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/66AD18D1572EF88D509E831201FDFAFC109CED28E17929B422B47CAEB6836792",
+      "display": "USDC.inj",
+      "name": "USD Coin (Injective)",
+      "symbol": "USDC.inj",
+      "coingecko_id": "usd-coin",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "injective",
+            "chain_id": "injective-1",
+            "base_denom": "erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a",
+            "channel_id": "channel-488"
+          },
+          "chain": {
+            "channel_id": "channel-113",
+            "path": "transfer/channel-113/erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a"
+          }
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "initia",
+            "chain_id": "interwoven-1",
+            "base_denom": "ibc/A64E1233F240D4B886413A12CF0300D6EC6FA0554DBD176119C399D0E2CA8048",
+            "channel_id": "channel-35"
+          },
+          "chain": {
+            "channel_id": "channel-0",
+            "path": "transfer/channel-0/transfer/channel-113/erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a"
+          }
+        }
+      ],
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/USDC.png"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/USDC.png"
+      }
+    },
+    {
       "description": "The native token of Celestia on Initia via IBC",
       "denom_units": [
         {

--- a/mainnets/inertia/assetlist.json
+++ b/mainnets/inertia/assetlist.json
@@ -146,6 +146,60 @@
       }
     },
     {
+      "description": "USDC from Injective",
+      "denom_units": [
+        {
+          "denom": "ibc/66AD18D1572EF88D509E831201FDFAFC109CED28E17929B422B47CAEB6836792",
+          "exponent": 0
+        },
+        {
+          "denom": "USDC.inj",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/66AD18D1572EF88D509E831201FDFAFC109CED28E17929B422B47CAEB6836792",
+      "display": "USDC.inj",
+      "name": "USD Coin (Injective)",
+      "symbol": "USDC.inj",
+      "coingecko_id": "usd-coin",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "injective",
+            "chain_id": "injective-1",
+            "base_denom": "erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a",
+            "channel_id": "channel-488"
+          },
+          "chain": {
+            "channel_id": "channel-113",
+            "path": "transfer/channel-113/erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a"
+          }
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "initia",
+            "chain_id": "interwoven-1",
+            "base_denom": "ibc/A64E1233F240D4B886413A12CF0300D6EC6FA0554DBD176119C399D0E2CA8048",
+            "channel_id": "channel-69"
+          },
+          "chain": {
+            "channel_id": "channel-0",
+            "path": "transfer/channel-0/transfer/channel-113/erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a"
+          }
+        }
+      ],
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/USDC.png"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/USDC.png"
+      }
+    },
+    {
       "description": "The LST of INIT by Inertia",
       "denom_units": [
         {

--- a/mainnets/initia/assetlist.json
+++ b/mainnets/initia/assetlist.json
@@ -72,6 +72,48 @@
       }
     },
     {
+      "description": "USDC from Injective",
+      "denom_units": [
+        {
+          "denom": "ibc/A64E1233F240D4B886413A12CF0300D6EC6FA0554DBD176119C399D0E2CA8048",
+          "exponent": 0
+        },
+        {
+          "denom": "USDC.inj",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/A64E1233F240D4B886413A12CF0300D6EC6FA0554DBD176119C399D0E2CA8048",
+      "display": "USDC.inj",
+      "name": "USD Coin (Injective)",
+      "symbol": "USDC.inj",
+      "coingecko_id": "usd-coin",
+      "oracle_symbol": "USDC",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "injective",
+            "chain_id": "injective-1",
+            "base_denom": "erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a",
+            "channel_id": "channel-488"
+          },
+          "chain": {
+            "channel_id": "channel-113",
+            "path": "transfer/channel-113/erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a"
+          }
+        }
+      ],
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/USDC.png"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/USDC.png"
+      }
+    },
+    {
       "description": "MilkyWay's Liquid Staked TIA",
       "denom_units": [
         {


### PR DESCRIPTION
## Summary

- add Injective-native USDC as `USDC.inj` on Initia, Echelon, Inertia, and Cabal
- register the live Injective ↔ Initia and Initia ↔ rollup IBC traces
- register Cabal Decimal Wrapper token `0xf27248Fc3C306cd9F9C72BDb768bc131C98694Cc` at 18 decimals
- leave all existing Noble-origin `USDC` entries unchanged

## On-chain verification

The paths in this PR were tested in both directions with a dedicated wallet:

- Injective → Initia: `C40C07F513DC1398ABA6B9C92869DB4469135765789BCF589CE2F4EC539756D9`
- Initia → Injective: `60E2D7F754C82ED688CDEC06E4AA8A3F7154C2D92BAA640C9E178922FE0BC456`
- Initia → Echelon, Inertia, and Cabal: `2F57B40562A087F97E7E88D9F2E51AA040AFF7FFA98946FE5A8BFAA803EBBE77`
- Echelon → Initia: `62E268659DEA6785F98E6905156F299C325C2825DF6D6D78CA282E7CC476AD7B`
- Inertia → Initia: `08E695F250A704F3154F22C312714B215E784F7CB6948E70CD49A9AAF38B215E`
- Cabal raw IBC → Initia: `6360F5CD0DC9906C30A3F2BA2BF96BA75EC3E349D0CCAC9C1AF251D1522CB5A2`
- Cabal Decimal Wrapper creation/wrap: `8E8F9E5DE6207AA064CA0481047D14BECFFE66BACBFB19145E5E4AAC4AB0122B`
- Cabal wrapped USDC.inj → Initia: `A318318905B613D202462C978CF2794607CF9D31BA0F0C9510EA3B33DCDD2CFA`

All tested IBC packet commitments cleared. Cabal live state confirms `localTokens(raw USDC.inj, 6)` resolves to the registered wrapper address.

## Validation

- repository `validate_assetlist.js` passed for all four changed files, including the live Cabal wrapper lookup
- all four files pass `assetlist.schema.json`
- JSON parsing and `git diff --check` pass
- independent review confirmed the existing Noble USDC entries are byte-for-byte unchanged

## Symbol transition

This PR implements the coexistence phase only: Noble remains `USDC`, and Injective USDC is introduced as `USDC.inj`. A later migration PR can rename Noble to `USDC.n` and promote Injective USDC to `USDC` after conversion liquidity and application integrations are ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the USDC.inj asset across Cabal, Echelon, Inertia, and Initia.
  * Included asset metadata, cross-chain transfer details, market identifier, and USDC imagery for display and recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->